### PR TITLE
Add results of device 'D-Team Newifi D2'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ sudo ./clean-up.sh
 
 | Device / CPU                     | OS / Kernel / iperf Param        | Speed          |
 | -------------------------------- | -------------------------------- | -------------- |
+| D-Team Newifi D2 / MT7621        | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   |
 | CMCC RAX3000M / MT7981           | OpenWRT 23.05.2 / 5.15.137       | 369 Mbits/sec  |
 | 360 T7 / MT7981                  | OpenWRT 23.05.0 / 5.15.134       | 369 Mbits/sec  |
 | Redmi AX6S / MT7622              | OpenWRT 23.05.2 / 5.15.137       | 391 Mbits/sec  |


### PR DESCRIPTION
```
root@OpenWrt:~# ./bench.sh 
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 47632 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  10.6 MBytes  89.0 Mbits/sec    0    168 KBytes       
[  5]   1.00-2.00   sec  11.2 MBytes  94.0 Mbits/sec    0    195 KBytes       
[  5]   2.00-3.00   sec  11.0 MBytes  92.6 Mbits/sec    0    195 KBytes       
[  5]   3.00-4.00   sec  11.1 MBytes  93.3 Mbits/sec    0    195 KBytes       
[  5]   4.00-5.00   sec  11.1 MBytes  93.3 Mbits/sec    0    204 KBytes       
[  5]   5.00-6.00   sec  11.1 MBytes  93.2 Mbits/sec    0    204 KBytes       
[  5]   6.00-7.00   sec  11.1 MBytes  93.4 Mbits/sec    0    204 KBytes       
[  5]   7.00-8.00   sec  11.0 MBytes  92.3 Mbits/sec    0    204 KBytes       
[  5]   8.00-9.00   sec  11.9 MBytes  99.6 Mbits/sec    0    289 KBytes       
[  5]   9.00-10.00  sec  11.2 MBytes  94.2 Mbits/sec    0    289 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   112 MBytes  93.5 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   111 MBytes  92.9 Mbits/sec                  receiver

iperf Done.
```