### PR TITLE
Update README.md: add Xeon and M2 Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sudo ./clean-up.sh
 | Intel Xeon Gold 6330             | Linux pve / 5.15.108             | 2.54 Gbits/sec | |
 | AMD EPYC 7302                    | Debian bookworm / 6.1.55         | 2.69 Gbits/sec | |
 | Intel Atom P5342                 | Debian bookworm / 6.1.0-16       | 2.89 Gbits/sec | |
+| Intel Xeon E3-1265L v3           | Debian trixie / 6.6.13           | 3.03 Gbits/sec | |
 | Raspberry Pi 5 / BCM2712*        | Raspberry Pi OS / 6.1.68         | 3.08 Gbits/sec | Reconfigure Kernel [#5](https://github.com/cyyself/wg-bench/issues/5) |
 | Mac Mini (2020) / Apple M1*      | AsahiLinux / 6.5.0 / -R          | 3.62 Gbits/sec | |
 | Intel Pentium(R) Silver N6005    | iStoreOS / 5.10.176              | 3.85 Gbits/sec | |
@@ -58,6 +59,7 @@ sudo ./clean-up.sh
 | Intel Core i5-8365U              | Debian bullseye / 5.10.0-24      | 5.64 Gbits/sec | |
 | Intel Core i9 13900K             | Debian trixie / 6.5.13           | 7.53 Gbits/sec | |
 | Intel Core i9 12900KS            | Ubuntu 22.04 / 6.2.0-32          | 8.30 Gbits/sec | |
+| MacBook Pro 2023 / Apple M2 Max* | Debian bookworm / 6.7.4-1 | 9.30 Gbits/sec | 4 core VZ VM |
 
 If you have more results to show, PR is welcomed.
 


### PR DESCRIPTION
The Xeon result is pretty normal stuff
The Mac stuff is virtualized inside a Lima VZ VM with 4 cores assigned.

The performance in the Mac benchmark can vary A LOT between VM restarts, although it keeps stable if you don't restart it. It can vary a lot also depending on the cores you assign, not necesarilly for the better with more cores.

Performance increase from 1 to 4 cores, but it can lower when you raise up to the 12 cores of this CPU. I think it's related to the cores you're assigned when starting the VM, knowing that it has 8 "performance" and 4 "efficiency" cores. There's some magic going on. It can go from 2GB/sec when you're assigned the bad cores, up to 10GB/sec when you get the good ones.

So the Xeon:
![Screenshot 2024-02-26 at 16 02 50](https://github.com/cyyself/wg-bench/assets/85222589/c897c810-a807-4fe8-aec3-e7a9c9e7b957)

And the Mac:
![Screenshot 2024-02-26 at 15 56 22](https://github.com/cyyself/wg-bench/assets/85222589/e7118237-8831-4f61-ae8a-3e3db487be1c)
