### PR TITLE
A script to run on a single line for OpenWrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ sudo ./clean-up.sh
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |
 | D-Team Newifi D2 / MT7621AT      | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   | |
 | Zyxel WSM20 / MT7621AT           | OpenWrt 23.05.2 / 5.15.137       | 98.3 Mbits/sec | |
+| ASUS RT-AX53U / MT7621AT         | OpenWrt 23.05.2 / 5.15.137       | 98.9 Mbits/sec  | |
 | Ubiquit EdgeRouter-X / MT7621AT  | OpenWrt 23.05.2 / 5.15.137       | 99 Mbits/sec   | |
+| Beeline SmartBox GIGA / MT7621A  | OpenWrt 23.05.2 / 5.15.137       | 100 Mbits/sec  | |
+| Beeline SmartBox PRO / MT7621AT  | OpenWrt 23.05.2 / 5.15.137       | 101 Mbits/sec  | |
 | Beeline SmartBox TURBO+ / MT7621A | OpenWrt Snapshot / 5.15.148       | 104 Mbits/sec  | |
 | TP-Link EC330-G5u V1 / MT7621A   | OpenWrt 23.05.2 / 5.15.137       | 104 Mbits/sec  | |
 | Google WiFi (Gale) / IPQ4019     | OpenWrt 23.05.2 / 5.15.137       | 164 Mbits/sec  | |

--- a/openwrt-benchmark.sh
+++ b/openwrt-benchmark.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+#set -x
+
+NAME=$(grep NAME /etc/os-release | head -n 1 | awk -F '"' '{print $2}')
+
+NETNS="wg-bench"
+NIC="wg-bench"
+HOST_VETH_IP="11.0.0.1"
+NS_VETH_IP="11.0.0.2"
+HOST_WG_IP="169.254.200.1"
+NS_WG_IP="169.254.200.2"
+HOST_PORT="11001"
+NS_PORT="11002"
+
+if [ "$NAME" != "OpenWrt" ]; then
+    echo "This is not OpenWrt. Exit"
+    exit 1
+fi
+
+if [ $(ls /tmp/opkg-lists/ | wc -l) -eq "0" ]; then
+    opkg update
+fi
+
+printf "\033[32;1m\nPackages:\033[0m\n"
+
+if opkg list-installed | grep -q wireguard-tools; then
+    echo "Wireguard already installed"
+else
+    echo "Installed wg..."
+    opkg install wireguard-tools
+fi
+
+if opkg list-installed | grep -q iperf3; then
+    echo "Iperf3 already installed"
+else
+    echo "Installed iperf3..."
+    opkg install iperf3
+fi
+
+if opkg list-installed | grep -q ip-full; then
+    echo "ip-full already installed"
+else
+    echo "Installed ip-full..."
+    opkg install ip-full
+fi
+
+if opkg list-installed | grep -q kmod-veth; then
+    echo "kmod-veth already installed"
+else
+    echo "Installed kmod-veth..."
+    opkg install kmod-veth
+fi
+
+if opkg list-installed | grep -q psmisc; then
+    echo "psmisc already installed"
+else
+    echo "Installed psmisc..."
+    opkg install psmisc
+fi
+
+printf "\033[32;1m\nRouters details:\033[0m\n"
+ubus call system board
+
+setup() {
+    # Create netns
+    ip netns add ${NETNS}
+
+    # Create veth
+    ip link add ${NIC} type veth peer name ${NIC}-ns
+    ip link set ${NIC}-ns netns ${NETNS}
+    ip addr add ${HOST_VETH_IP}/30 dev ${NIC}
+    ip netns exec ${NETNS} ip addr add ${NS_VETH_IP}/30 dev ${NIC}-ns
+    ip link set ${NIC} up
+    ip netns exec ${NETNS} ip link set ${NIC}-ns up
+
+    # Setup WG for host
+    wg genkey > host-privkey 2> /dev/null
+    wg genkey > ns-privkey 2> /dev/null
+    ip link add ${NIC}-wg type wireguard
+    wg set ${NIC}-wg listen-port ${HOST_PORT} private-key host-privkey
+    ip addr add ${HOST_WG_IP}/32 dev ${NIC}-wg peer ${NS_WG_IP}
+    wg set ${NIC}-wg peer $(wg pubkey < ns-privkey) allowed-ips ${NS_WG_IP}/32 endpoint ${NS_VETH_IP}:${NS_PORT}
+    ip link set ${NIC}-wg up
+
+    # Setup WG for netns
+    ip netns exec ${NETNS} ip link add ${NIC}-wg type wireguard
+    ip netns exec ${NETNS} wg set ${NIC}-wg listen-port ${NS_PORT} private-key $PWD/ns-privkey
+    ip netns exec ${NETNS} ip addr add ${NS_WG_IP}/32 dev ${NIC}-wg peer ${HOST_WG_IP}
+    ip netns exec ${NETNS} wg set ${NIC}-wg peer $(wg pubkey < $PWD/host-privkey) allowed-ips ${HOST_WG_IP}/32 endpoint ${HOST_VETH_IP}:${HOST_PORT}
+    ip netns exec ${NETNS} ip link set ${NIC}-wg up
+    rm host-privkey
+    rm ns-privkey
+}
+
+
+bench() {
+    ip netns exec ${NETNS} iperf3 -s -D -p 4242
+    sleep 2
+    iperf3 -c ${NS_WG_IP} $@ -p 4242
+    ip netns exec ${NETNS} fuser -k 4242/tcp
+}
+
+clean() {
+    # Delete netns
+    ip netns del ${NETNS}
+
+    # Delete veth
+    ip link del ${NIC}
+
+    # Delete WG
+    ip link del ${NIC}-wg
+}
+
+setup
+bench
+clean


### PR DESCRIPTION
Merged three of your scripts into one. This has the following advantages:
- Run with one command. No git and no need to run the three scripts one by one
- Installing the necessary packages for OpenWrt
- Displayed router information

I also fixed the kill for iperf3. I often had it failing on a PID file. Kill by port works without issues. Also added a delay.
Command for download and run (my fork for example):
```
sh <(wget -O - https://raw.githubusercontent.com/itdoginfo/wg-bench/master/openwrt-benchmark.sh)
```

Output
```
Packages:
Wireguard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Routers details:
{
	"kernel": "5.15.137",
	"hostname": "OpenWrt",
	"system": "MediaTek MT7621 ver:1 eco:3",
	"model": "ASUS RT-AX53U",
	"board_name": "asus,rt-ax53u",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "23.05.2",
		"revision": "r23630-842932a63d",
		"target": "ramips/mt7621",
		"description": "OpenWrt 23.05.2 r23630-842932a63d"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 38614 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  11.2 MBytes  93.8 Mbits/sec    0    188 KBytes       
[  5]   1.00-2.00   sec  11.9 MBytes  99.7 Mbits/sec    0    199 KBytes       
[  5]   2.00-3.00   sec  11.7 MBytes  97.8 Mbits/sec    0    231 KBytes       
[  5]   3.00-4.00   sec  12.0 MBytes   100 Mbits/sec    0    231 KBytes       
[  5]   4.00-5.00   sec  11.7 MBytes  98.4 Mbits/sec    0    231 KBytes       
[  5]   5.00-6.00   sec  11.7 MBytes  98.3 Mbits/sec    0    231 KBytes       
[  5]   6.00-7.00   sec  11.8 MBytes  98.8 Mbits/sec    0    243 KBytes       
[  5]   7.00-8.00   sec  11.9 MBytes  99.6 Mbits/sec    0    243 KBytes       
[  5]   8.00-9.00   sec  11.9 MBytes  99.9 Mbits/sec    0    346 KBytes       
[  5]   9.00-10.00  sec  12.2 MBytes   102 Mbits/sec    0    346 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   118 MBytes  98.9 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   117 MBytes  98.1 Mbits/sec                  receiver

iperf Done.
```