### PR TITLE
Update README.md - add i5 8500

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ sudo ./clean-up.sh
 | Intel Pentium(R) Silver N6005    | iStoreOS / 5.10.176              | 3.85 Gbits/sec | |
 | Intel N100                       | Debian bookworm / 6.1.76         | 3.97 Gbits/sec | |
 | Intel Core i5-4590               | Debian bookworm / 6.1.38         | 4.21 Gbits/sec | |
+| Intel Core i5-8500               | Ubuntu 22.04.3 / 5.15.0          | 4.49 Gbits/sec | |
 | Intel Core i7-8565U              | Debian trixie / 6.7.6 xanmod     | 4.93 Gbits/sec | Xanmod Kernel |
 | AMD Ryzen 5 PRO 5650GE           | Linux pve / 6.2.16               | 5.29 Gbits/sec | |
 | AMD Ryzen 9 7950X                | Ubuntu 22.04.3 / 5.15.0          | 5.64 Gbits/sec | |


### PR DESCRIPTION
added test results for Intel i5 8500 on Ubuntu 22.04.3 / 5.15.0 @ 4.49Gbits/sec