### PR TITLE
Added benchmarks for TP-Link WR841N v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Raspberry Pi Model B / BCM2835   | OpenWrt 23.05.2 / 5.15.137       | 16.1 Mbits/sec | |
 | Buffalo WCR-1166DS / MT7628AN    | OpenWrt 23.05.2 / 5.15.137       | 18.3 Mbits/sec | |
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
+| TP-Link WR841N v9 /QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |
 | D-Team Newifi D2 / MT7621AT      | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   | |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Raspberry Pi Model B / BCM2835   | OpenWrt 23.05.2 / 5.15.137       | 16.1 Mbits/sec | |
 | Buffalo WCR-1166DS / MT7628AN    | OpenWrt 23.05.2 / 5.15.137       | 18.3 Mbits/sec | |
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
-| TP-Link WR841N v9 /QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
+| TP-Link WR841N v9 / QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |
 | D-Team Newifi D2 / MT7621AT      | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   | |


### PR DESCRIPTION
Hi,
just benchmarked on my WR841N and wanted to share the results. Full results can be found here:

```sh
Routers details:
{
        "kernel": "5.10.201",
        "hostname": "OpenWrt",
        "system": "Qualcomm Atheros QCA9533 ver 1 rev 1",
        "model": "TP-Link TL-WR841N/ND v9",
        "board_name": "tplink,tl-wr841-v9",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "22.03.6",
                "revision": "r20265-f85a79bcb4",
                "target": "ath79/tiny",
                "description": "OpenWrt 22.03.6 r20265-f85a79bcb4"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 33388 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  2.29 MBytes  19.2 Mbits/sec    0    102 KBytes       
[  5]   1.00-2.00   sec  2.27 MBytes  19.0 Mbits/sec    0    132 KBytes       
[  5]   2.00-3.00   sec  2.27 MBytes  19.0 Mbits/sec    0    142 KBytes       
[  5]   3.00-4.00   sec  2.21 MBytes  18.5 Mbits/sec    0    142 KBytes       
[  5]   4.00-5.00   sec  2.27 MBytes  19.0 Mbits/sec    0    163 KBytes       
[  5]   5.00-6.00   sec  2.21 MBytes  18.5 Mbits/sec    0    163 KBytes       
[  5]   6.00-7.00   sec  2.33 MBytes  19.5 Mbits/sec    0    163 KBytes       
[  5]   7.00-8.00   sec  2.15 MBytes  18.0 Mbits/sec    0    163 KBytes       
[  5]   8.00-9.00   sec  2.33 MBytes  19.5 Mbits/sec    0    273 KBytes       
[  5]   9.00-10.00  sec  2.51 MBytes  21.1 Mbits/sec    0    273 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  22.8 MBytes  19.2 Mbits/sec    0             sender

```