### PR TITLE
Add OpenWrt One

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | 360 T7 / MT7981                  | OpenWRT 23.05.0 / 5.15.134       | 369 Mbits/sec  | |
 | GL-iNet MT3000 / MT7981          | GL 5.4.211 / 5.10.0              | 369 Mbits/sec  | |
 | Xiaomi AX3000T / MT7981          | OpenWrt Snapshot / 6.1.82        | 371 Mbits/sec  | |
+| OpenWrt One / MT7981             | OpenWrt Snapshot / 6.6.43        | 375 Mbits/sec  | |
 | Routerich AX3000 / MT7981        | OpenWRT 23.05.2 / 5.15.137       | 381 Mbits/sec  | |
 | Netgear WAX206 / MT7622          | OpenWRT 23.05.2 / 5.15.137       | 381 Mbits/sec  | |
 | Redmi AX6S / MT7622              | OpenWRT 23.05.2 / 5.15.137       | 391 Mbits/sec  | |


### PR DESCRIPTION
```
Routers details:
{
	"kernel": "6.6.43",
	"hostname": "OpenWrt",
	"system": "ARMv8 Processor rev 4",
	"model": "OpenWrt One",
	"board_name": "openwrt,one",
	"rootfs_type": "initramfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "SNAPSHOT",
		"revision": "r27044-249b949a26",
		"target": "mediatek/filogic",
		"description": "OpenWrt SNAPSHOT r27044-249b949a26"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 36154 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  46.4 MBytes   388 Mbits/sec    0    847 KBytes       
[  5]   1.00-2.00   sec  45.2 MBytes   379 Mbits/sec    0   1023 KBytes       
[  5]   2.00-3.00   sec  43.0 MBytes   360 Mbits/sec    0   1023 KBytes       
[  5]   3.00-4.00   sec  45.2 MBytes   380 Mbits/sec    0   1.05 MBytes       
[  5]   4.00-5.01   sec  44.1 MBytes   367 Mbits/sec    0   1.05 MBytes       
[  5]   5.01-6.00   sec  43.2 MBytes   366 Mbits/sec    0   1.05 MBytes       
[  5]   6.00-7.00   sec  45.5 MBytes   382 Mbits/sec    0   1.12 MBytes       
[  5]   7.00-8.00   sec  44.1 MBytes   370 Mbits/sec    0   1.17 MBytes       
[  5]   8.00-9.00   sec  45.0 MBytes   378 Mbits/sec    0   1.23 MBytes       
[  5]   9.00-10.00  sec  45.1 MBytes   378 Mbits/sec    0   1.23 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   447 MBytes   375 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   444 MBytes   372 Mbits/sec                  receiver
```