### PR TITLE
Add P&W R619AC (ipq4019 @ 896 Mhz OC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Beeline SmartBox TURBO+ / MT7621A | OpenWrt Snapshot / 5.15.148       | 104 Mbits/sec  | |
 | TP-Link EC330-G5u V1 / MT7621A   | OpenWrt 23.05.2 / 5.15.137       | 104 Mbits/sec  | |
 | Google WiFi (Gale) / IPQ4019     | OpenWrt 23.05.2 / 5.15.137       | 164 Mbits/sec  | |
+| P&W R619AC 128M / IPQ4019     | OpenWrt 23.05.4 / 5.15.164       | 201 Mbits/sec  | Overclocked 896 MHz |
 | Xiaomi Mi Router R3D / IPQ8064   | OpenWrt Snapshot / 6.1.77       | 214 Mbits/sec  | |
 | NanoPi R2S / RK3328              | OpenWrt 23.05.2 / 5.15.137       | 234 Mbits/sec  | |
 | Intel Atom E3825                 | OpenWrt 23.05.2 / 5.15.137       | 259 Mbits/sec  | |


### PR DESCRIPTION
Routers details:
{
	"kernel": "5.15.164",
	"hostname": "R619AC",
	"system": "ARMv7 Processor rev 5 (v7l)",
	"model": "P&W R619AC 128M",
	"board_name": "p2w,r619ac-128m",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "23.05.4",
		"revision": "r24012-d8dd03c46f",
		"target": "ipq40xx/generic",
		"description": "OpenWrt 23.05.4 r24012-d8dd03c46f"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 56952 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  23.2 MBytes   195 Mbits/sec    0    337 KBytes
[  5]   1.00-2.00   sec  23.6 MBytes   198 Mbits/sec    0    369 KBytes
[  5]   2.00-3.00   sec  24.8 MBytes   208 Mbits/sec    0    383 KBytes
[  5]   3.00-4.00   sec  24.1 MBytes   202 Mbits/sec    0    383 KBytes
[  5]   4.00-5.00   sec  24.9 MBytes   209 Mbits/sec    0    407 KBytes
[  5]   5.00-6.00   sec  24.1 MBytes   202 Mbits/sec    0    407 KBytes
[  5]   6.00-7.00   sec  24.1 MBytes   202 Mbits/sec    0    407 KBytes
[  5]   7.00-8.00   sec  23.5 MBytes   197 Mbits/sec    0    407 KBytes
[  5]   8.00-9.00   sec  24.2 MBytes   204 Mbits/sec    0    407 KBytes
[  5]   9.00-10.00  sec  24.5 MBytes   205 Mbits/sec    0    407 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   241 MBytes   202 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   240 MBytes   201 Mbits/sec                  receiver

iperf Done.
4242/tcp:             6962

count=348485 us50=19860 us250=98010 diff=78150 cpu_MHz=891.836