### PR TITLE
Add TP-Link Archer C7 v2 (a very common device)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
 | TP-Link WR841N v9 / QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
+| TP-Link Archer C7 v2 / QCA9558   | OpenWrt 23.05.5 / 5.15.167       | 35.2 Mbits/sec | | 
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |
 | D-Team Newifi D2 / MT7621AT      | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   | |
 | Zyxel WSM20 / MT7621AT           | OpenWrt 23.05.2 / 5.15.137       | 98.3 Mbits/sec | |


### PR DESCRIPTION
```
Routers details:
{
	"kernel": "5.15.167",
	"hostname": "darkstar",
	"system": "Qualcomm Atheros QCA9558 ver 1 rev 0",
	"model": "TP-Link Archer C7 v2",
	"board_name": "tplink,archer-c7-v2",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "23.05.5",
		"revision": "r24106-10cc5fcd00",
		"target": "ath79/generic",
		"description": "OpenWrt 23.05.5 r24106-10cc5fcd00"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 57420 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  4.50 MBytes  37.7 Mbits/sec    0    199 KBytes
[  5]   1.00-2.00   sec  4.38 MBytes  36.7 Mbits/sec    0    238 KBytes
[  5]   2.00-3.00   sec  4.12 MBytes  34.6 Mbits/sec    0    262 KBytes
[  5]   3.00-4.00   sec  4.12 MBytes  34.6 Mbits/sec    0    275 KBytes
[  5]   4.00-5.00   sec  4.38 MBytes  36.7 Mbits/sec    0    297 KBytes
[  5]   5.00-6.00   sec  4.00 MBytes  33.6 Mbits/sec    0    297 KBytes
[  5]   6.00-7.00   sec  4.25 MBytes  35.6 Mbits/sec    0    314 KBytes
[  5]   7.00-8.00   sec  4.12 MBytes  34.6 Mbits/sec    0    314 KBytes
[  5]   8.00-9.00   sec  4.00 MBytes  33.6 Mbits/sec    0    314 KBytes
[  5]   9.00-10.00  sec  4.12 MBytes  34.6 Mbits/sec    0    314 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  42.0 MBytes  35.2 Mbits/sec    0             sender
[  5]   0.00-10.02  sec  41.4 MBytes  34.7 Mbits/sec                  receiver

iperf Done.
4242/tcp:            10757
```