### PR TITLE
Added Dell Wyse 3040 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |
 | Intel Celeron(R) J1800           | Ubuntu 22.04.3 / 5.15.0          | 551 Mbits/sec  | |
+| Dell Wyse 3040 / Intel Atom x5-Z8350 | OpenWRT 23.05.5 / 5.15.167   | 581 Mbits/sec  | All cores run on "performance" cpufreq governor |
 | Redmi AX6 / IPQ8071A             | OpenWRT Snapshot / 6.1.77        | 603 Mbits/sec  | |
 | Radxa E20C / RK3528              | iStoreOS / 5.10.201              | 620 Mbits/sec  | |
 | Raspberry Pi 4 / BCM2711*        | archlinux / 6.1.61(armv7l)       | 665 Mbits/sec  | |


### PR DESCRIPTION
Router details:
{
        "kernel": "5.15.167",
        "hostname": "OpenWRT-Wyse-3040",
        "system": "Intel(R) Atom(TM) x5-Z8350  CPU @ 1.44GHz",
        "model": "Dell Inc. Wyse 3040 Thin Client",
        "board_name": "dell-inc-wyse-3040-thin-client",
        "rootfs_type": "ext4",
        "release": {
                "distribution": "OpenWrt",
                "version": "23.05.5",
                "revision": "r24106-10cc5fcd00",
                "target": "x86/64",
                "description": "OpenWrt 23.05.5 r24106-10cc5fcd00"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 60396 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  67.5 MBytes   566 Mbits/sec    0    526 KBytes       
[  5]   1.00-2.00   sec  67.5 MBytes   566 Mbits/sec    0    562 KBytes       
[  5]   2.00-3.00   sec  69.1 MBytes   580 Mbits/sec    0    592 KBytes       
[  5]   3.00-4.00   sec  68.4 MBytes   574 Mbits/sec    0    592 KBytes       
[  5]   4.00-5.00   sec  68.2 MBytes   572 Mbits/sec    0    699 KBytes       
[  5]   5.00-6.00   sec  70.6 MBytes   593 Mbits/sec    0    736 KBytes       
[  5]   6.00-7.00   sec  71.5 MBytes   600 Mbits/sec    0    736 KBytes       
[  5]   7.00-8.00   sec  71.1 MBytes   597 Mbits/sec    0    736 KBytes       
[  5]   8.00-9.00   sec  70.0 MBytes   587 Mbits/sec    0    736 KBytes       
[  5]   9.00-10.00  sec  70.5 MBytes   591 Mbits/sec    0    771 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   694 MBytes   583 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   693 MBytes   581 Mbits/sec                  receiver

iperf Done.
4242/tcp:            31866