### PR TITLE
Added Linksys MX4300 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Linksys WRT3200ACM / 88F6820     | OpenWRT 23.05.2 / 5.15.137       | 426 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT664 (1.8GHz) | deepin V23 Beta3 / 5.10.209 | 437 Mbits/sec  | With FT310 "little" cores disabled |
 | Milk-V Pioneer / SG2042          | RevyOS / 6.1.61                  | 440 Mbits/sec  | |
-| Raspberry Pi Zero 2W / BCM2710A1 | OpenWRT 23.05.2 / 5.15.137       | 443 Mbits/sec  | |
+| Raspberry Pi Zero 2W / BCM2710A1 |    OpenWRT 23.05.2 / 5.15.137    | 443 Mbits/sec  | |
+| Linksys MX4300                   | OpenWRT 24.10.0-rc2 / 6.6.63     | 443 Mbits/sec  | |
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.63",
        "hostname": "MX4300",
        "system": "ARMv8 Processor rev 4",
        "model": "Linksys MX4300",
        "board_name": "linksys,mx4300",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.0-rc2",
                "revision": "r28161-ea17e958b9",
                "target": "qualcommax/ipq807x",
                "description": "OpenWrt 24.10.0-rc2 r28161-ea17e958b9",
                "builddate": "1733226068"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 56434 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  55.5 MBytes   465 Mbits/sec    0    293 KBytes
[  5]   1.00-2.00   sec  54.0 MBytes   453 Mbits/sec    0    306 KBytes
[  5]   2.00-3.00   sec  53.8 MBytes   451 Mbits/sec    0    321 KBytes
[  5]   3.00-4.00   sec  53.2 MBytes   447 Mbits/sec    0    321 KBytes
[  5]   4.00-5.00   sec  53.2 MBytes   447 Mbits/sec    0    358 KBytes
[  5]   5.00-6.00   sec  53.1 MBytes   446 Mbits/sec    0    358 KBytes
[  5]   6.00-7.00   sec  54.0 MBytes   453 Mbits/sec    0    358 KBytes
[  5]   7.00-8.00   sec  53.4 MBytes   448 Mbits/sec    0    358 KBytes
[  5]   8.00-9.00   sec  53.1 MBytes   446 Mbits/sec    0    358 KBytes
[  5]   9.00-10.00  sec  53.9 MBytes   452 Mbits/sec    0    358 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   537 MBytes   451 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   536 MBytes   450 Mbits/sec                  receiver

iperf Done.
4242/tcp:            12118