### PR TITLE
Add Linksys E8450 and MX4300

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Netgear R7800 / IPQ8065          | OpenWrt 23.05.2 / 5.15.137       | 291 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT310 (1.5GHz) | deepin V23 Beta3 / 5.10.209 | 358 Mbits/sec | With FT664 "big" cores disabled |
 | Linksys WRT1900ACv2  / 88F6820   | OpenWrt 23.05.2 / 5.15.137       | 361 Mbits/sec  | |
-| Linksys E8450 (UBI)              | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |
+| Linksys E8450 (UBI) / MT7622BV   | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |
 | CMCC RAX3000M / MT7981           | OpenWRT 23.05.2 / 5.15.137       | 369 Mbits/sec  | |
 | 360 T7 / MT7981                  | OpenWRT 23.05.0 / 5.15.134       | 369 Mbits/sec  | |
 | GL-iNet MT3000 / MT7981          | GL 5.4.211 / 5.10.0              | 369 Mbits/sec  | |
@@ -66,7 +66,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Phytium Pi (V2.2) / E2000Q FT664 (1.8GHz) | deepin V23 Beta3 / 5.10.209 | 437 Mbits/sec  | With FT310 "little" cores disabled |
 | Milk-V Pioneer / SG2042          | RevyOS / 6.1.61                  | 440 Mbits/sec  | |
 | Raspberry Pi Zero 2W / BCM2710A1 | OpenWRT 23.05.2 / 5.15.137       | 443 Mbits/sec  | |
-| Linksys MX4300                   | OpenWRT 24.10.0-rc2 / 6.6.63     | 443 Mbits/sec  | |
+| Linksys MX4300 / IPQ8174         | OpenWRT 24.10.0-rc2 / 6.6.63     | 443 Mbits/sec  | |
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Netgear R7800 / IPQ8065          | OpenWrt 23.05.2 / 5.15.137       | 291 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT310 (1.5GHz) | deepin V23 Beta3 / 5.10.209 | 358 Mbits/sec | With FT664 "big" cores disabled |
 | Linksys WRT1900ACv2  / 88F6820   | OpenWrt 23.05.2 / 5.15.137       | 361 Mbits/sec  | |
+| Linksys E8450 (UBI)              | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |
 | CMCC RAX3000M / MT7981           | OpenWRT 23.05.2 / 5.15.137       | 369 Mbits/sec  | |
 | 360 T7 / MT7981                  | OpenWRT 23.05.0 / 5.15.134       | 369 Mbits/sec  | |
 | GL-iNet MT3000 / MT7981          | GL 5.4.211 / 5.10.0              | 369 Mbits/sec  | |
@@ -65,6 +66,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Phytium Pi (V2.2) / E2000Q FT664 (1.8GHz) | deepin V23 Beta3 / 5.10.209 | 437 Mbits/sec  | With FT310 "little" cores disabled |
 | Milk-V Pioneer / SG2042          | RevyOS / 6.1.61                  | 440 Mbits/sec  | |
 | Raspberry Pi Zero 2W / BCM2710A1 | OpenWRT 23.05.2 / 5.15.137       | 443 Mbits/sec  | |
+| Linksys MX4300                   | OpenWRT 24.10.0-rc2 / 6.6.63     | 443 Mbits/sec  | |
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |


### PR DESCRIPTION
Added Linksys E8450 (including previous pull request with Linksys MX4300)
Router details:
{
        "kernel": "5.15.167",
        "hostname": "E8450",
        "system": "ARMv8 Processor rev 4",
        "model": "Linksys E8450 (UBI)",
        "board_name": "linksys,e8450-ubi",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "23.05.5",
                "revision": "r24106-10cc5fcd00",
                "target": "mediatek/mt7622",
                "description": "OpenWrt 23.05.5 r24106-10cc5fcd00"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 38426 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  45.8 MBytes   383 Mbits/sec    0   1.00 MBytes
[  5]   1.00-2.00   sec  45.0 MBytes   378 Mbits/sec    0   1.40 MBytes
[  5]   2.00-3.00   sec  45.2 MBytes   380 Mbits/sec   48   1.06 MBytes
[  5]   3.00-4.00   sec  44.9 MBytes   376 Mbits/sec    0   1.18 MBytes
[  5]   4.00-5.00   sec  44.6 MBytes   374 Mbits/sec    0   1.30 MBytes
[  5]   5.00-6.00   sec  44.4 MBytes   372 Mbits/sec    6    981 KBytes
[  5]   6.00-7.00   sec  44.6 MBytes   374 Mbits/sec    0   1.02 MBytes
[  5]   7.00-8.00   sec  44.8 MBytes   375 Mbits/sec    0   1.06 MBytes
[  5]   8.00-9.00   sec  43.9 MBytes   368 Mbits/sec    0   1.11 MBytes
[  5]   9.00-10.00  sec  44.1 MBytes   370 Mbits/sec    0   1.13 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   448 MBytes   376 Mbits/sec   54             sender
[  5]   0.00-10.01  sec   446 MBytes   374 Mbits/sec                  receiver

iperf Done.
4242/tcp:             5745