### PR TITLE
Add nanopi r6c

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Redmi AX6 / IPQ8071A             | OpenWRT Snapshot / 6.1.77        | 603 Mbits/sec  | |
 | Radxa E20C / RK3528              | iStoreOS / 5.10.201              | 620 Mbits/sec  | |
 | Raspberry Pi 4 / BCM2711*        | archlinux / 6.1.61(armv7l)       | 665 Mbits/sec  | |
+| NanoPi R6C / RK3588S             | OpenWrt 24.10.0-rc5 / 6.6.69     | 728 Mbits/sec  | |
 | Mercusys MR90X v1 / MT7986       | OpenWRT 23.05.2 / 5.15.137       | 754 Mbits/sec  | |
 | Intel Celeron N2930              | OpenWRT 23.05.2 / 5.15.137       | 762 Mbits/sec  | |
 | OrangePi 5 / Rockchip rk3588s*   | Armbian 23.8.1 / 5.10.110        | 772 Mbits/sec  | |


### PR DESCRIPTION
Router details:
{
	"kernel": "6.6.69",
	"hostname": "OpenWrt",
	"system": "ARMv8 Processor rev 0",
	"model": "FriendlyElec NanoPi R6C",
	"board_name": "friendlyarm,nanopi-r6c",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "24.10.0-rc5",
		"revision": "r28304-6dacba30a7",
		"target": "rockchip/armv8",
		"description": "OpenWrt 24.10.0-rc5 r28304-6dacba30a7",
		"builddate": "1736026537"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 37934 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  88.5 MBytes   742 Mbits/sec    0    371 KBytes       
[  5]   1.00-2.00   sec  87.0 MBytes   730 Mbits/sec    0    371 KBytes       
[  5]   2.00-3.00   sec  87.0 MBytes   730 Mbits/sec    0    391 KBytes       
[  5]   3.00-4.00   sec  87.4 MBytes   733 Mbits/sec    0    411 KBytes       
[  5]   4.00-5.00   sec  86.2 MBytes   724 Mbits/sec    0    411 KBytes       
[  5]   5.00-6.00   sec  85.5 MBytes   717 Mbits/sec    0    411 KBytes       
[  5]   6.00-7.00   sec  86.4 MBytes   725 Mbits/sec    0    411 KBytes       
[  5]   7.00-8.00   sec  86.8 MBytes   728 Mbits/sec    0    411 KBytes       
[  5]   8.00-9.00   sec  86.4 MBytes   725 Mbits/sec    0    411 KBytes       
[  5]   9.00-10.00  sec  86.6 MBytes   726 Mbits/sec    0    411 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   868 MBytes   728 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   867 MBytes   727 Mbits/sec                  receiver

iperf Done.
4242/tcp:             4033
