### PR TITLE
Add UniFi AP AC-LR benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | TP-Link WR841N v9 / QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
 | TP-Link Archer C7 v2 / QCA9558   | OpenWrt 23.05.5 / 5.15.167       | 35.2 Mbits/sec | | 
+| Ubiquiti UniFi AC LR / QCA956X   | OpenWrt 24.10.0 / 6.6.73         | 35.6 Mbits/sec | |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 CONFIG_PREEMPT   | 38.1 Mbits/sec | Highest of 10 runs |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 PREEMPT_NONE     | 47.2 Mbits/sec | Highest of 10 runs |
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |


### PR DESCRIPTION
```
root@fw:~# sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh)
Downloading 'https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh'
Connecting to 2606:50c0:8002::154:443
Writing to stdout
-                    100% |*******************************|  2908   0:00:00 ETA
Download completed (2908 bytes)

Packages:                                                                                                          
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:                                                                                                    
{
        "kernel": "6.6.73",
        "hostname": "fw",
        "system": "Qualcomm Atheros QCA956X ver 1 rev 0",
        "model": "Ubiquiti UniFi AC LR",
        "board_name": "ubnt,unifiac-lr",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.0",
                "revision": "r28427-6df0e3d02a",
                "target": "ath79/generic",
                "description": "OpenWrt 24.10.0 r28427-6df0e3d02a",
                "builddate": "1738624177"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 35350 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.01   sec  4.62 MBytes  38.5 Mbits/sec    0    215 KBytes       
[  5]   1.01-2.01   sec  4.62 MBytes  38.9 Mbits/sec    0    398 KBytes       
[  5]   2.01-3.00   sec  4.88 MBytes  41.1 Mbits/sec    0    580 KBytes       
[  5]   3.00-4.01   sec  4.50 MBytes  37.6 Mbits/sec    0    580 KBytes       
[  5]   4.01-5.00   sec  4.50 MBytes  37.9 Mbits/sec    0    580 KBytes       
[  5]   5.00-6.00   sec  4.25 MBytes  35.5 Mbits/sec    0    580 KBytes       
[  5]   6.00-7.01   sec  3.75 MBytes  31.3 Mbits/sec    0    580 KBytes       
[  5]   7.01-8.00   sec  3.50 MBytes  29.6 Mbits/sec    0    580 KBytes       
[  5]   8.00-9.00   sec  3.62 MBytes  30.4 Mbits/sec    0    580 KBytes       
[  5]   9.00-10.02  sec  4.25 MBytes  34.9 Mbits/sec    0    580 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.02  sec  42.5 MBytes  35.6 Mbits/sec    0             sender
[  5]   0.00-10.07  sec  42.4 MBytes  35.3 Mbits/sec                  receiver

iperf Done.
4242/tcp:            18973
Cannot find device "wg-bench"
```