### PR TITLE
Add Cudy TR3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | GL-iNet MT3000 / MT7981          | GL 5.4.211 / 5.10.0              | 369 Mbits/sec  | |
 | Xiaomi AX3000T / MT7981          | OpenWrt Snapshot / 6.1.82        | 371 Mbits/sec  | |
 | OpenWrt One / MT7981             | OpenWrt Snapshot / 6.6.43        | 375 Mbits/sec  | |
+| Cudy TR3000 v1 / MT7981BA        | OpenWrt 24.10.0 / 6.6.73         | 377 Mbits/sec  | |
 | Routerich AX3000 / MT7981        | OpenWRT 23.05.2 / 5.15.137       | 381 Mbits/sec  | |
 | Netgear WAX206 / MT7622          | OpenWRT 23.05.2 / 5.15.137       | 381 Mbits/sec  | |
 | Redmi AX6S / MT7622              | OpenWRT 23.05.2 / 5.15.137       | 391 Mbits/sec  | |


### PR DESCRIPTION
```
Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:
{
	"kernel": "6.6.73",
	"hostname": "OpenWrt",
	"system": "ARMv8 Processor rev 4",
	"model": "Cudy TR3000 v1",
	"board_name": "cudy,tr3000-v1",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "24.10.0",
		"revision": "r28427-6df0e3d02a",
		"target": "mediatek/filogic",
		"description": "OpenWrt 24.10.0 r28427-6df0e3d02a",
		"builddate": "1738624177"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 47476 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.01   sec  45.6 MBytes   380 Mbits/sec    0    798 KBytes
[  5]   1.01-2.00   sec  44.9 MBytes   378 Mbits/sec    0    842 KBytes
[  5]   2.00-3.00   sec  46.5 MBytes   390 Mbits/sec    0   1.09 MBytes
[  5]   3.00-4.00   sec  45.8 MBytes   384 Mbits/sec    0   1.09 MBytes
[  5]   4.00-5.01   sec  44.6 MBytes   372 Mbits/sec    0   1.17 MBytes
[  5]   5.01-6.00   sec  45.2 MBytes   382 Mbits/sec    0   1.23 MBytes
[  5]   6.00-7.00   sec  45.2 MBytes   380 Mbits/sec    0   1.23 MBytes
[  5]   7.00-8.00   sec  45.1 MBytes   379 Mbits/sec    0   1.42 MBytes
[  5]   8.00-9.00   sec  44.6 MBytes   374 Mbits/sec    0   1.42 MBytes
[  5]   9.00-10.00  sec  45.4 MBytes   381 Mbits/sec    0   1.42 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   453 MBytes   380 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   450 MBytes   377 Mbits/sec                  receiver

iperf Done.
4242/tcp:             3681
```