### PR TITLE
Add EdgeRouter 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | NanoPi R2S / RK3328              | OpenWrt 23.05.2 / 5.15.137       | 234 Mbits/sec  | |
 | Intel Atom E3825                 | OpenWrt 23.05.2 / 5.15.137       | 259 Mbits/sec  | |
 | UFI001C (UFI003) / MSM8916       | OpenStick / [5.15.0](https://github.com/OpenStick/linux) | 260 Mbits/sec | |
+| Ubiquiti EdgeRouter 4 / Cavium CN7130  | OpenWrt 24.10.0 / 6.6.73   | 271 Mbits/sec  | |
 | Netgear R7800 / IPQ8065          | OpenWrt 23.05.2 / 5.15.137       | 291 Mbits/sec  | |
 | Lemote A1310 / Loongson 3B1500   | AOSC OS 12.0.4 / 6.12.13-aosc-lts | 315 Mbits/sec | CPU reversion 3B1500G, dual-channel memory @ 1066MHz, with firmware PMON-A1310-1.1.0-8cores-official.bin, highest of 10 runs |
 | NanoPi R5S / RK3568              | OpenWrt 24.10.0-rc4 / 6.12.6     | 318 Mbits/sec  | |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.73",
        "hostname": "OpenWrt",
        "system": "UBNT_E300 (CN7030p1.2-1000-AAP)",
        "model": "Ubiquiti EdgeRouter 4",
        "board_name": "ubnt,edgerouter-4",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.0",
                "revision": "r28427-6df0e3d02a",
                "target": "octeon/generic",
                "description": "OpenWrt 24.10.0 r28427-6df0e3d02a",
                "builddate": "1738624177"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 59124 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  33.8 MBytes   283 Mbits/sec    0    269 KBytes
[  5]   1.00-2.00   sec  31.9 MBytes   267 Mbits/sec    0    269 KBytes
[  5]   2.00-3.00   sec  31.0 MBytes   260 Mbits/sec    0    299 KBytes
[  5]   3.00-4.00   sec  29.2 MBytes   246 Mbits/sec    0    318 KBytes
[  5]   4.00-5.00   sec  32.8 MBytes   275 Mbits/sec    0    318 KBytes
[  5]   5.00-6.00   sec  33.4 MBytes   280 Mbits/sec    0    318 KBytes
[  5]   6.00-7.00   sec  33.2 MBytes   279 Mbits/sec    0    318 KBytes
[  5]   7.00-8.00   sec  33.9 MBytes   284 Mbits/sec    0    318 KBytes
[  5]   8.00-9.00   sec  32.8 MBytes   275 Mbits/sec    0    318 KBytes
[  5]   9.00-10.00  sec  32.8 MBytes   274 Mbits/sec    0    318 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   325 MBytes   272 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   323 MBytes   271 Mbits/sec                  receiver

iperf Done.
4242/tcp:             4310