### PR TITLE
Add GL-AXT1800

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Netgear WAX206 / MT7622          | OpenWRT 23.05.2 / 5.15.137       | 381 Mbits/sec  | |
 | Redmi AX6S / MT7622              | OpenWRT 23.05.2 / 5.15.137       | 391 Mbits/sec  | |
 | StarFive VisionFive 2 / JH7110   | Debian trixie / 5.15.0           | 402 Mbits/sec  | |
+| GL.iNet GL-AXT1800 / IPQ6000     | OpenWRT SNAPSHOT / 6.6.84        | 414 Mbits/sec  | arm64 system by VIKINGYFY/immortalwrt, bypass os-release NAME check |
 | Lemote A1801 / Loongson 3A3000-LP | Debian bookworm / 5.10.209      | 423 Mbits/sec  | CPU reversion variant H2, clocked at 1.45GHz |
 | Linksys WRT3200ACM / 88F6820     | OpenWRT 23.05.2 / 5.15.137       | 426 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT664 (1.8GHz) | deepin V23 Beta3 / 5.10.209 | 437 Mbits/sec  | With FT310 "little" cores disabled |


### PR DESCRIPTION
```
Router details:
{
        "kernel": "6.6.84",
        "hostname": "axt1800",
        "system": "ARMv8 Processor rev 4",
        "model": "GL.iNet GL-AXT1800",
        "board_name": "glinet,gl-axt1800",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "ImmortalWrt",
                "version": "SNAPSHOT",
                "firmware_url": "https://downloads.immortalwrt.org/",
                "revision": "r33620-989f2c9462",
                "target": "qualcommax/ipq60xx",
                "description": "ImmortalWrt SNAPSHOT r33620-989f2c9462",
                "builddate": "1743488039"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 37276 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  51.6 MBytes   433 Mbits/sec    0    403 KBytes
[  5]   1.00-2.00   sec  49.5 MBytes   415 Mbits/sec    0    315 KBytes
[  5]   2.00-3.00   sec  50.0 MBytes   419 Mbits/sec    0    478 KBytes
[  5]   3.00-4.00   sec  48.6 MBytes   408 Mbits/sec    0    433 KBytes
[  5]   4.00-5.00   sec  47.4 MBytes   397 Mbits/sec    0    307 KBytes
[  5]   5.00-6.00   sec  50.5 MBytes   423 Mbits/sec    0    315 KBytes
[  5]   6.00-7.00   sec  48.8 MBytes   409 Mbits/sec    0    430 KBytes
[  5]   7.00-8.00   sec  49.8 MBytes   417 Mbits/sec    0    318 KBytes
[  5]   8.00-9.00   sec  50.8 MBytes   426 Mbits/sec    0    305 KBytes
[  5]   9.00-10.00  sec  49.0 MBytes   411 Mbits/sec    0    302 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   496 MBytes   416 Mbits/sec    0            sender
[  5]   0.00-10.00  sec   494 MBytes   414 Mbits/sec                  receiver

iperf Done.
```

system by https://github.com/VIKINGYFY/immortalwrt, an immortalwrt fork, immortalwrt is an openwrt fork