### PR TITLE
Add Cisco/Viptela vEdge 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | NanoPi R2S / RK3328              | OpenWrt 23.05.2 / 5.15.137       | 234 Mbits/sec  | |
 | Intel Atom E3825                 | OpenWrt 23.05.2 / 5.15.137       | 259 Mbits/sec  | |
 | UFI001C (UFI003) / MSM8916       | OpenStick / [5.15.0](https://github.com/OpenStick/linux) | 260 Mbits/sec | |
+| Cisco/Viptela vEdge 1000 / Cavium CN6130  | OpenWrt 24.10.1 / 6.6.86   | 260 Mbits/sec  | |
 | Ubiquiti EdgeRouter 4 / Cavium CN7130  | OpenWrt 24.10.0 / 6.6.73   | 271 Mbits/sec  | |
 | Netgear R7800 / IPQ8065          | OpenWrt 23.05.2 / 5.15.137       | 291 Mbits/sec  | |
 | Lemote A1310 / Loongson 3B1500   | AOSC OS 12.0.4 / 6.12.13-aosc-lts | 315 Mbits/sec | CPU reversion 3B1500G, dual-channel memory @ 1066MHz, with firmware PMON-A1310-1.1.0-8cores-official.bin, highest of 10 runs |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.86",
        "hostname": "OpenWrt",
        "system": "UBNT_E200 (CN6130p1.1-1000-NSP)",
        "model": "Cisco/Viptela vEdge 1000",
        "board_name": "cisco,vedge1000",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "octeon/generic",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 60258 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.01   sec  31.8 MBytes   265 Mbits/sec    0    254 KBytes
[  5]   1.01-2.00   sec  30.5 MBytes   257 Mbits/sec    0    254 KBytes
[  5]   2.00-3.00   sec  31.1 MBytes   261 Mbits/sec    0    254 KBytes
[  5]   3.00-4.00   sec  31.0 MBytes   260 Mbits/sec    0    254 KBytes
[  5]   4.00-5.00   sec  30.5 MBytes   256 Mbits/sec    0    254 KBytes
[  5]   5.00-6.00   sec  31.6 MBytes   265 Mbits/sec    0    254 KBytes
[  5]   6.00-7.00   sec  30.4 MBytes   255 Mbits/sec    0    254 KBytes
[  5]   7.00-8.00   sec  31.1 MBytes   261 Mbits/sec    0    254 KBytes
[  5]   8.00-9.00   sec  30.8 MBytes   258 Mbits/sec    0    254 KBytes
[  5]   9.00-10.00  sec  31.4 MBytes   263 Mbits/sec    0    254 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   310 MBytes   260 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   309 MBytes   259 Mbits/sec                  receiver

iperf Done.
4242/tcp:             7717