### PR TITLE
Add NanoPi R3S

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |
+| FriendlyELEC NanoPi R3S / RK3566 | OpenWRT 24.10.1 / 6.6.86         | 544 Mbits/sec  | Default OpenWRT firewall settings |
 | Intel Celeron(R) J1800           | Ubuntu 22.04.3 / 5.15.0          | 551 Mbits/sec  | |
 | Dell Wyse 3040 / Intel Atom x5-Z8350 | OpenWRT 23.05.5 / 5.15.167   | 581 Mbits/sec  | All cores run on "performance" cpufreq governor |
 | Redmi AX6 / IPQ8071A             | OpenWRT Snapshot / 6.1.77        | 603 Mbits/sec  | |
 | Radxa E20C / RK3528              | iStoreOS / 5.10.201              | 620 Mbits/sec  | |
 | Raspberry Pi 4 / BCM2711*        | archlinux / 6.1.61(armv7l)       | 665 Mbits/sec  | |
+| FriendlyELEC NanoPi R3S / RK3566 | OpenWRT 24.10.1 / 6.6.86         | 695 Mbits/sec  | Firewall disabled |
 | NanoPi R6C / RK3588S             | OpenWrt 24.10.0-rc5 / 6.6.69     | 728 Mbits/sec  | |
 | Banana Pi BPI-R3 Mini / MT7986A  | OpenWRT 24.10.0-rc5 / 6.6.69     | 730 Mbits/sec  | |
 | Mercusys MR90X v1 / MT7986       | OpenWRT 23.05.2 / 5.15.137       | 754 Mbits/sec  | |


### PR DESCRIPTION
```
root@OpenWrt:~# sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh)
Downloading 'https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh'
Connecting to 185.199.110.133:443
Writing to stdout
-                    100% |*******************************|  2941   0:00:00 ETA
Download completed (2941 bytes)

Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:
{
        "kernel": "6.6.86",
        "hostname": "OpenWrt",
        "system": "ARMv8 Processor rev 0",
        "model": "FriendlyElec NanoPi R3S",
        "board_name": "friendlyarm,nanopi-r3s",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "rockchip/armv8",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 56990 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  65.2 MBytes   547 Mbits/sec    0    327 KBytes
[  5]   1.00-2.00   sec  65.0 MBytes   545 Mbits/sec    0    327 KBytes
[  5]   2.00-3.00   sec  65.0 MBytes   545 Mbits/sec    0    345 KBytes
[  5]   3.00-4.00   sec  64.9 MBytes   544 Mbits/sec    0    345 KBytes
[  5]   4.00-5.00   sec  65.2 MBytes   547 Mbits/sec    0    361 KBytes
[  5]   5.00-6.00   sec  65.2 MBytes   548 Mbits/sec    0    361 KBytes
[  5]   6.00-7.00   sec  64.8 MBytes   543 Mbits/sec    0    361 KBytes
[  5]   7.00-8.00   sec  64.8 MBytes   543 Mbits/sec    0    361 KBytes
[  5]   8.00-9.00   sec  64.2 MBytes   539 Mbits/sec    0    361 KBytes
[  5]   9.00-10.00  sec  65.0 MBytes   545 Mbits/sec    0    361 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   650 MBytes   545 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   649 MBytes   544 Mbits/sec                  receiver

iperf Done.
4242/tcp:             4686
```
With firewall disabled:
```
root@OpenWrt:~# /etc/init.d/firewall stop
root@OpenWrt:~# sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh)
Downloading 'https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh'
Connecting to 185.199.110.133:443
Writing to stdout
-                    100% |*******************************|  2941   0:00:00 ETA
Download completed (2941 bytes)

Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:
{
        "kernel": "6.6.86",
        "hostname": "OpenWrt",
        "system": "ARMv8 Processor rev 0",
        "model": "FriendlyElec NanoPi R3S",
        "board_name": "friendlyarm,nanopi-r3s",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "rockchip/armv8",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 46126 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  85.5 MBytes   716 Mbits/sec    0    448 KBytes
[  5]   1.00-2.00   sec  84.2 MBytes   707 Mbits/sec    0    517 KBytes
[  5]   2.00-3.00   sec  83.4 MBytes   699 Mbits/sec    0    517 KBytes
[  5]   3.00-4.00   sec  83.1 MBytes   697 Mbits/sec    0    517 KBytes
[  5]   4.00-5.00   sec  83.2 MBytes   698 Mbits/sec    0    548 KBytes
[  5]   5.00-6.00   sec  82.5 MBytes   692 Mbits/sec    0    548 KBytes
[  5]   6.00-7.00   sec  81.9 MBytes   687 Mbits/sec    0    580 KBytes
[  5]   7.00-8.00   sec  81.6 MBytes   685 Mbits/sec    0    580 KBytes
[  5]   8.00-9.00   sec  82.2 MBytes   690 Mbits/sec    0    580 KBytes
[  5]   9.00-10.00  sec  81.4 MBytes   682 Mbits/sec    0    580 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   829 MBytes   695 Mbits/sec    0             sender
[  5]   0.00-10.01  sec   828 MBytes   695 Mbits/sec                  receiver

iperf Done.
4242/tcp:             4352
