### PR TITLE
Results for TP-Link Archer C2600

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Raspberry Pi Model B / BCM2835   | OpenWrt 23.05.2 / 5.15.137       | 16.1 Mbits/sec | |
 | Buffalo WCR-1166DS / MT7628AN    | OpenWrt 23.05.2 / 5.15.137       | 18.3 Mbits/sec | |
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
-| TP-Link WR841N v9 / QCA9533       | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
+| TP-Link WR841N v9 / QCA9533      | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
-| TP-Link Archer C7 v2 / QCA9558   | OpenWrt 23.05.5 / 5.15.167       | 35.2 Mbits/sec | | 
+| TP-Link Archer C7 v2 / QCA9558   | OpenWrt 23.05.5 / 5.15.167       | 35.2 Mbits/sec | |
 | Ubiquiti UniFi AC LR / QCA956X   | OpenWrt 24.10.0 / 6.6.73         | 35.6 Mbits/sec | |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 CONFIG_PREEMPT   | 38.1 Mbits/sec | Highest of 10 runs |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 PREEMPT_NONE     | 47.2 Mbits/sec | Highest of 10 runs |
@@ -50,6 +50,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Xiaomi Mi Router R3D / IPQ8064   | OpenWrt Snapshot / 6.1.77       | 214 Mbits/sec  | |
 | NanoPi R2S / RK3328              | OpenWrt 23.05.2 / 5.15.137       | 234 Mbits/sec  | |
 | Rock Cubie A5E / A527            | Armbian 25.5.0 / 6.14.0          | 245 Mbits/sec  | |
+| TP-Link Archer C2600 v1.x / IPQ8064 | OpenWrt 23.05.4 / 5.15.162    | 250 Mbits/sec  | |
 | Intel Atom E3825                 | OpenWrt 23.05.2 / 5.15.137       | 259 Mbits/sec  | |
 | UFI001C (UFI003) / MSM8916       | OpenStick / [5.15.0](https://github.com/OpenStick/linux) | 260 Mbits/sec | |
 | Cisco/Viptela vEdge 1000 / Cavium CN6130  | OpenWrt 24.10.1 / 6.6.86   | 260 Mbits/sec  | |


### PR DESCRIPTION
```
Router details:
{
        "kernel": "5.15.162",
        "hostname": "myname",
        "system": "ARMv7 Processor rev 0 (v7l)",
        "model": "TP-Link Archer C2600",
        "board_name": "tplink,c2600",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "23.05.4",
                "revision": "r24012-d8dd03c46f",
                "target": "ipq806x/generic",
                "description": "OpenWrt 23.05.4 r24012-d8dd03c46f"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 45812 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  31.1 MBytes   261 Mbits/sec    0    615 KBytes       
[  5]   1.00-2.00   sec  30.6 MBytes   257 Mbits/sec    0    946 KBytes       
[  5]   2.00-3.00   sec  28.9 MBytes   242 Mbits/sec    0   1.22 MBytes       
[  5]   3.00-4.00   sec  30.4 MBytes   255 Mbits/sec    0   1.48 MBytes       
[  5]   4.00-5.00   sec  29.2 MBytes   245 Mbits/sec  173   1.21 MBytes       
[  5]   5.00-6.00   sec  29.5 MBytes   247 Mbits/sec    0   1.32 MBytes       
[  5]   6.00-7.00   sec  29.8 MBytes   250 Mbits/sec    0   1.40 MBytes       
[  5]   7.00-8.00   sec  30.4 MBytes   255 Mbits/sec   65   1.04 MBytes       
[  5]   8.00-9.00   sec  29.5 MBytes   248 Mbits/sec    0   1.12 MBytes       
[  5]   9.00-10.00  sec  29.2 MBytes   245 Mbits/sec    0   1.15 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   299 MBytes   250 Mbits/sec  238             sender
[  5]   0.00-10.03  sec   296 MBytes   248 Mbits/sec                  receiver
```

For `-R` I had to edit `openwrt-benchmark.sh` as I see no other way to pass it.
```
Connecting to host 169.254.200.2, port 4242
Reverse mode, remote host 169.254.200.2 is sending
[  5] local 169.254.200.1 port 33176 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  27.2 MBytes   228 Mbits/sec                  
[  5]   1.00-2.00   sec  28.1 MBytes   236 Mbits/sec                  
[  5]   2.00-3.00   sec  28.9 MBytes   242 Mbits/sec                  
[  5]   3.00-4.00   sec  29.8 MBytes   250 Mbits/sec                  
[  5]   4.00-5.00   sec  28.5 MBytes   239 Mbits/sec                  
[  5]   5.00-6.00   sec  29.2 MBytes   245 Mbits/sec                  
[  5]   6.00-7.00   sec  29.2 MBytes   245 Mbits/sec                  
[  5]   7.00-8.00   sec  29.1 MBytes   244 Mbits/sec                  
[  5]   8.00-9.00   sec  28.5 MBytes   239 Mbits/sec                  
[  5]   9.00-10.00  sec  30.0 MBytes   252 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   292 MBytes   245 Mbits/sec   66             sender
[  5]   0.00-10.00  sec   289 MBytes   242 Mbits/sec                  receiver
```