### PR TITLE
Add Banana Pi BPI-M2 ZERO (Allwinner H2+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Cisco/Viptela vEdge 1000 / Cavium CN6130  | OpenWrt 24.10.1 / 6.6.86   | 260 Mbits/sec  | |
 | Ubiquiti EdgeRouter 4 / Cavium CN7130  | OpenWrt 24.10.0 / 6.6.73   | 271 Mbits/sec  | |
 | Netgear R7800 / IPQ8065          | OpenWrt 23.05.2 / 5.15.137       | 291 Mbits/sec  | |
+| Banana Pi BPI-M2 ZERO / Allwinner H2+ | Armbian 25.5.0 / 6.12.23    | 295 Mbits/sec  | |
 | Lemote A1310 / Loongson 3B1500   | AOSC OS 12.0.4 / 6.12.13-aosc-lts | 315 Mbits/sec | CPU reversion 3B1500G, dual-channel memory @ 1066MHz, with firmware PMON-A1310-1.1.0-8cores-official.bin, highest of 10 runs |
 | NanoPi R5S / RK3568              | OpenWrt 24.10.0-rc4 / 6.12.6     | 318 Mbits/sec  | |
 | Radxa Orion O6 / Cix P1*         | Debian sid / 6.12.9              | 320 Mbits/sec | With all cores enabled |


### PR DESCRIPTION
```
glucy2@bananapim2zero:~/wg-bench$ sudo ./benchmark.sh 
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 42372 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  35.5 MBytes   298 Mbits/sec    0    387 KBytes       
[  5]   1.00-2.01   sec  36.1 MBytes   301 Mbits/sec    0    411 KBytes       
[  5]   2.01-3.00   sec  34.5 MBytes   291 Mbits/sec    0    438 KBytes       
[  5]   3.00-4.00   sec  34.9 MBytes   292 Mbits/sec    0    409 KBytes       
[  5]   4.00-5.01   sec  35.4 MBytes   295 Mbits/sec    0    502 KBytes       
[  5]   5.01-6.01   sec  35.8 MBytes   301 Mbits/sec    0    534 KBytes       
[  5]   6.01-7.00   sec  34.2 MBytes   290 Mbits/sec    0    465 KBytes       
[  5]   7.00-8.00   sec  35.5 MBytes   298 Mbits/sec    0    516 KBytes       
[  5]   8.00-9.00   sec  34.2 MBytes   287 Mbits/sec    0    358 KBytes       
[  5]   9.00-10.00  sec  35.8 MBytes   300 Mbits/sec    0   5.34 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   352 MBytes   295 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   349 MBytes   293 Mbits/sec                  receiver

iperf Done.
glucy2@bananapim2zero:~/wg-bench$ sudo ./clean-up.sh 
```

```
glucy2@bananapim2zero
---------------------
OS: Armbian_community 25.5.0-trunk.444 bookworm armv7l
Host: Banana Pi BPI-M2-Zero
Kernel: Linux 6.12.23-current-sunxi
Uptime: 17 mins
Packages: 309 (dpkg)
Shell: bash 5.2.15
Terminal: /dev/ttyS0
Terminal Font: VGA default kernel font
CPU: sun8i-h2-plus (4) @ 1.30 GHz
GPU: Allwinner sun8i-h3-mali [Integrated]
Memory: 75.76 MiB / 484.39 MiB (16%)
Swap: 0 B / 242.19 MiB (0%)
Disk (/): 1.07 GiB / 57.12 GiB (2%) - ext4
Disk (/var/log): 1.14 MiB / 46.84 MiB (2%) - ext4
Local IP (wlan0): 192.168.101.131/24
Locale: en_SG.UTF-8
```