### PR TITLE
openwrt-benchmark.sh: Fixed the conditional to check OpenWrt

### DIFF
--- a/openwrt-benchmark.sh
+++ b/openwrt-benchmark.sh
@@ -2,7 +2,7 @@
 
 #set -x
 
-NAME=$(grep NAME /etc/os-release | head -n 1 | awk -F '"' '{print $2}')
+[ -s /etc/os-release ] && . /etc/os-release
 
 NETNS="wg-bench"
 NIC="wg-bench"
@@ -13,7 +13,7 @@ NS_WG_IP="169.254.200.2"
 HOST_PORT="11001"
 NS_PORT="11002"
 
-if [ "$NAME" != "OpenWrt" ] && [ "$NAME" != "ImmortalWrt" ]; then
+if [ "$ID_LIKE" != "lede openwrt" ]; then
     echo "This is not OpenWrt. Exit"
     exit 1
 fi


### PR DESCRIPTION
openwrt-benchmark.sh: Fixed the conditional to check OpenWrt, use the `ID_LIKE` variable instead.

In China, there are various OpenWrt distributions, such as QWRT, LEAN LEDE, iStoreOS etc.
The `ID` key in `/etc/os-release` may be various.
I think switching to `ID_LIKE` is the best adaption.