### PR TITLE
Added GL.iNet GL-B3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Beeline SmartBox PRO / MT7621AT  | OpenWrt 23.05.2 / 5.15.137       | 101 Mbits/sec  | |
 | Beeline SmartBox TURBO+ / MT7621A | OpenWrt Snapshot / 5.15.148       | 104 Mbits/sec  | |
 | TP-Link EC330-G5u V1 / MT7621A   | OpenWrt 23.05.2 / 5.15.137       | 104 Mbits/sec  | |
+| GL.iNet GL-B3000 / IPQ5018       | OpenWrt SNAPSHOT / 6.6.89        | 122 Mbits/sec  | |
 | Google WiFi (Gale) / IPQ4019     | OpenWrt 23.05.2 / 5.15.137       | 164 Mbits/sec  | |
 | AVM FRITZ!Box 7530 / ipq40xx     | OpenWrt 23.05.2 / 5.15.137       | 184 Mbits/sec | |
 | P&W R619AC 128M / IPQ4019     | OpenWrt 23.05.4 / 5.15.164       | 201 Mbits/sec  | Overclocked 896 MHz |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.89",
        "hostname": "GL-B3000",
        "system": "ARMv8 Processor rev 4",
        "model": "GL.iNet GL-B3000",
        "board_name": "glinet,gl-b3000",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "SNAPSHOT",
                "firmware_url": "https://downloads.openwrt.org/",
                "revision": "r29548-2a9316fbfb",
                "target": "qualcommax/ipq50xx",
                "description": "OpenWrt SNAPSHOT r29548-2a9316fbfb",
                "builddate": "1746969968"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 50486 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  13.9 MBytes   116 Mbits/sec    0    411 KBytes
[  5]   1.00-2.00   sec  14.5 MBytes   122 Mbits/sec    0    556 KBytes
[  5]   2.00-3.00   sec  14.5 MBytes   121 Mbits/sec    0    627 KBytes
[  5]   3.00-4.00   sec  14.6 MBytes   123 Mbits/sec    0    627 KBytes
[  5]   4.00-5.00   sec  15.2 MBytes   128 Mbits/sec    0    661 KBytes
[  5]   5.00-6.01   sec  14.5 MBytes   121 Mbits/sec    0    661 KBytes
[  5]   6.01-7.00   sec  14.5 MBytes   123 Mbits/sec    0    661 KBytes
[  5]   7.00-8.00   sec  15.0 MBytes   126 Mbits/sec    0    661 KBytes
[  5]   8.00-9.00   sec  15.2 MBytes   128 Mbits/sec    0    661 KBytes
[  5]   9.00-10.02  sec  16.0 MBytes   131 Mbits/sec    0    712 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.02  sec   148 MBytes   124 Mbits/sec    0            sender
[  5]   0.00-10.04  sec   146 MBytes   122 Mbits/sec                  receiver

iperf Done.