### PR TITLE
Added EdgeRouter Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Ubiquiti UniFi AC LR / QCA956X   | OpenWrt 24.10.0 / 6.6.73         | 35.6 Mbits/sec | |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 CONFIG_PREEMPT   | 38.1 Mbits/sec | Highest of 10 runs |
 | Lemote Fuloong / Loongson 2F     | Gentoo / 6.1.74 PREEMPT_NONE     | 47.2 Mbits/sec | Highest of 10 runs |
+|Ubiquiti EdgeRouter Lite / Octeon CN5020 | OpenWrt 24.10.1 / 6.6.86  | 48.5 Mbits/sec | |
 | GL-iNet MT1300 / MT7621A         | OpenWrt 23.05.2 / 5.15.137       | 82.5 Mbits/sec | |
 | D-Team Newifi D2 / MT7621AT      | OpenWrt 23.05.2 / 5.15.137       | 93 Mbits/sec   | |
 | Zyxel WSM20 / MT7621AT           | OpenWrt 23.05.2 / 5.15.137       | 98.3 Mbits/sec | |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.86",
        "hostname": "OpenWrt",
        "system": "UBNT_E100 (CN5020p1.1-500-SCP)",
        "model": "UBNT_E100 (CN5020p1.1-500-SCP)",
        "board_name": "erlite",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "octeon/generic",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 56768 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  6.12 MBytes  51.3 Mbits/sec    0    174 KBytes
[  5]   1.00-2.00   sec  5.88 MBytes  49.3 Mbits/sec    0    192 KBytes
[  5]   2.00-3.00   sec  6.00 MBytes  50.3 Mbits/sec    0    210 KBytes
[  5]   3.00-4.00   sec  5.62 MBytes  47.2 Mbits/sec    0    222 KBytes
[  5]   4.00-5.00   sec  6.12 MBytes  51.3 Mbits/sec    0    222 KBytes
[  5]   5.00-6.00   sec  5.50 MBytes  46.2 Mbits/sec    0    234 KBytes
[  5]   6.00-7.00   sec  5.75 MBytes  48.1 Mbits/sec    0    234 KBytes
[  5]   7.00-8.00   sec  6.62 MBytes  55.6 Mbits/sec    0    311 KBytes
[  5]   8.00-9.00   sec  5.75 MBytes  48.2 Mbits/sec    0    318 KBytes
[  5]   9.00-10.00  sec  5.88 MBytes  49.3 Mbits/sec    0    318 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  59.2 MBytes  49.7 Mbits/sec    0             sender
[  5]   0.00-10.01  sec  57.9 MBytes  48.5 Mbits/sec                  receiver

iperf Done.
4242/tcp:             6196