### PR TITLE
Added Fortinet Fortigate 50E

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | NanoPi R5S / RK3568              | OpenWrt 24.10.0-rc4 / 6.12.6     | 318 Mbits/sec  | |
 | Radxa Orion O6 / Cix P1*         | Debian sid / 6.12.9              | 320 Mbits/sec | With all cores enabled |
 | Lemote A1601 / Loongson 3A2000   | AOSC OS 12.0.4 / 6.12.13-aosc-lts | 346 Mbits/sec | Highest of 5 runs |
+| Fortinet FortiGate 50E / 88F6820 | OpenWrt 24.10.1 / 6.6.86         | 347 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT310 (1.5GHz) | deepin V23 Beta3 / 5.10.209 | 358 Mbits/sec | With FT664 "big" cores disabled |
 | Linksys WRT1900ACv2  / 88F6820   | OpenWrt 23.05.2 / 5.15.137       | 361 Mbits/sec  | |
 | Linksys E8450 (UBI) / MT7622BV   | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |


### PR DESCRIPTION
Router details:
{
        "kernel": "6.6.86",
        "hostname": "FortiGate50E",
        "system": "ARMv7 Processor rev 1 (v7l)",
        "model": "Fortinet FortiGate 50E",
        "board_name": "fortinet,fg-50e",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "mvebu/cortexa9",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 54612 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  44.2 MBytes   371 Mbits/sec    0    981 KBytes
[  5]   1.00-2.00   sec  41.6 MBytes   348 Mbits/sec    0   1.34 MBytes
[  5]   2.00-3.00   sec  43.4 MBytes   365 Mbits/sec  130   1.18 MBytes
[  5]   3.00-4.00   sec  42.1 MBytes   353 Mbits/sec    0   1.25 MBytes
[  5]   4.00-5.00   sec  41.5 MBytes   348 Mbits/sec    0   1.42 MBytes
[  5]   5.00-6.00   sec  42.4 MBytes   356 Mbits/sec   37   1.05 MBytes
[  5]   6.00-7.00   sec  42.5 MBytes   357 Mbits/sec    0   1.12 MBytes
[  5]   7.00-8.00   sec  39.1 MBytes   328 Mbits/sec    0   1.14 MBytes
[  5]   8.00-9.00   sec  37.4 MBytes   313 Mbits/sec    0   1.19 MBytes
[  5]   9.00-10.00  sec  41.9 MBytes   351 Mbits/sec    0   1.21 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   416 MBytes   349 Mbits/sec  167             sender
[  5]   0.00-10.02  sec   414 MBytes   347 Mbits/sec                  receiver

iperf Done.
4242/tcp:            15943