### PR TITLE
Add result for GL.iNet GL-MT2500

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Fortinet FortiGate 50E / 88F6820 | OpenWrt 24.10.1 / 6.6.86         | 347 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT310 (1.5GHz) | deepin V23 Beta3 / 5.10.209 | 358 Mbits/sec | With FT664 "big" cores disabled |
 | Linksys WRT1900ACv2  / 88F6820   | OpenWrt 23.05.2 / 5.15.137       | 361 Mbits/sec  | |
+| GL.iNet GL-MT2500 (Brume 2)      | OpenWrt 21.02-SNAPSHOT           | 362 Mbits/sec  | |
 | Linksys E8450 (UBI) / MT7622BV   | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |
 | CMCC RAX3000M / MT7981           | OpenWRT 23.05.2 / 5.15.137       | 369 Mbits/sec  | |
 | 360 T7 / MT7981                  | OpenWRT 23.05.0 / 5.15.134       | 369 Mbits/sec  | |


### PR DESCRIPTION
```root@GL-MT2500:~# wget -O /tmp/benchmark.sh https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh
Downloading 'https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt-benchmark.sh'
Connecting to 185.199.111.133:443
Writing to '/tmp/benchmark.sh'
/tmp/benchmark.sh    100% |*******************************|  2889   0:00:00 ETA
Download completed (2889 bytes)
root@GL-MT2500:~# chmod +x /tmp/benchmark.sh
root@GL-MT2500:~# sh /tmp/benchmark.sh
Downloading https://fw.gl-inet.com/releases/v21.02.3/kmod-4.2.1/aarch64_cortex-a53/mediatek/mt7981/Packages.gz
Updated list of available packages in /var/opkg-lists/glinet_kmod
Downloading https://fw.gl-inet.com/releases/v21.02.3/packages-4.0/aarch64_cortex-a53/glinet/Packages.gz
Updated list of available packages in /var/opkg-lists/glinet_gli_pub
Downloading https://fw.gl-inet.com/releases/v21.02.3/packages-4.0/aarch64_cortex-a53/packages/Packages.gz
Updated list of available packages in /var/opkg-lists/glinet_gli_packages
Updating database.
Database update completed.

Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
Installed kmod-veth...
Installing kmod-veth (5.4.211-1) to root...
Downloading https://fw.gl-inet.com/releases/v21.02.3/kmod-4.2.1/aarch64_cortex-a53/mediatek/mt7981/kmod-veth_5.4.211-1_aarch64_cortex-a53.ipk
Configuring kmod-veth.
Updating database.
Database update completed.
Installed psmisc...
Installing psmisc (23.4-2) to root...
Downloading https://fw.gl-inet.com/releases/v21.02.3/packages-4.0/aarch64_cortex-a53/packages/psmisc_23.4-2_aarch64_cortex-a53.ipk
Configuring psmisc.
Updating database.
Database update completed.

Router details:
{
	"kernel": "5.4.211",
	"hostname": "GL-MT2500",
	"system": "ARMv8 Processor rev 4",
	"model": "GL.iNet GL-MT2500",
	"board_name": "glinet,mt2500-emmc",
	"release": {
		"distribution": "OpenWrt",
		"version": "21.02-SNAPSHOT",
		"revision": "r15812+912-46b6ee7ffc",
		"target": "mediatek/mt7981",
		"description": "OpenWrt 21.02-SNAPSHOT r15812+912-46b6ee7ffc"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 58584 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.01   sec  41.4 MBytes   345 Mbits/sec    0    892 KBytes       
[  5]   1.01-2.00   sec  43.2 MBytes   364 Mbits/sec  104   1.08 MBytes       
[  5]   2.00-3.00   sec  42.5 MBytes   357 Mbits/sec    0   1.23 MBytes       
[  5]   3.00-4.00   sec  43.8 MBytes   367 Mbits/sec    0   1.32 MBytes       
[  5]   4.00-5.00   sec  42.5 MBytes   357 Mbits/sec    5    998 KBytes       
[  5]   5.00-6.00   sec  43.8 MBytes   367 Mbits/sec    0   1.04 MBytes       
[  5]   6.00-7.00   sec  43.8 MBytes   367 Mbits/sec    0   1.08 MBytes       
[  5]   7.00-8.00   sec  46.2 MBytes   388 Mbits/sec    0   1.11 MBytes       
[  5]   8.00-9.00   sec  43.8 MBytes   367 Mbits/sec    0   1.12 MBytes       
[  5]   9.00-10.00  sec  43.8 MBytes   367 Mbits/sec    0   1.13 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   435 MBytes   365 Mbits/sec  109             sender
[  5]   0.00-10.01  sec   432 MBytes   362 Mbits/sec                  receiver

iperf Done.
4242/tcp:             7349
root@GL-MT2500:~# sh /tmp/benchmark.sh -R

Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:
{
	"kernel": "5.4.211",
	"hostname": "GL-MT2500",
	"system": "ARMv8 Processor rev 4",
	"model": "GL.iNet GL-MT2500",
	"board_name": "glinet,mt2500-emmc",
	"release": {
		"distribution": "OpenWrt",
		"version": "21.02-SNAPSHOT",
		"revision": "r15812+912-46b6ee7ffc",
		"target": "mediatek/mt7981",
		"description": "OpenWrt 21.02-SNAPSHOT r15812+912-46b6ee7ffc"
	}
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 47258 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  43.2 MBytes   362 Mbits/sec    0   1.02 MBytes       
[  5]   1.00-2.00   sec  43.5 MBytes   365 Mbits/sec    0   1.34 MBytes       
[  5]   2.00-3.00   sec  42.5 MBytes   357 Mbits/sec   62   1.08 MBytes       
[  5]   3.00-4.00   sec  43.8 MBytes   367 Mbits/sec    0   1.19 MBytes       
[  5]   4.00-5.00   sec  43.8 MBytes   367 Mbits/sec    0   1.27 MBytes       
[  5]   5.00-6.00   sec  43.8 MBytes   366 Mbits/sec    0   1.33 MBytes       
[  5]   6.00-7.00   sec  43.8 MBytes   368 Mbits/sec    0   1.36 MBytes       
[  5]   7.00-8.00   sec  41.2 MBytes   346 Mbits/sec    6   1.00 MBytes       
[  5]   8.00-9.00   sec  45.0 MBytes   377 Mbits/sec    0   1.04 MBytes       
[  5]   9.00-10.00  sec  45.0 MBytes   378 Mbits/sec    0   1.11 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   436 MBytes   365 Mbits/sec   68             sender
[  5]   0.00-10.01  sec   432 MBytes   362 Mbits/sec                  receiver

iperf Done.
4242/tcp:             8486
root@GL-MT2500:~# ```