### PR TITLE
Added Benchmark Result for NanoPi R5C

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |
+| FriendlyELECT NanoPi R5C / RK3568B2 | OpenWRT / 24.10.1             | 537 Mbits/sec  | |
 | FriendlyELEC NanoPi R3S / RK3566 | OpenWRT 24.10.1 / 6.6.86         | 544 Mbits/sec  | Default OpenWRT firewall settings |
 | Intel Celeron(R) J1800           | Ubuntu 22.04.3 / 5.15.0          | 551 Mbits/sec  | |
 | Dell Wyse 3040 / Intel Atom x5-Z8350 | OpenWRT 23.05.5 / 5.15.167   | 581 Mbits/sec  | All cores run on "performance" cpufreq governor |


### PR DESCRIPTION
root@OpenWRT-R5C:~# ./openwrt-benchmark.sh

Packages:
WireGuard already installed
Iperf3 already installed
ip-full already installed
kmod-veth already installed
psmisc already installed

Router details:
{
        "kernel": "6.6.86",
        "hostname": "OpenWRT-R5C",
        "system": "ARMv8 Processor rev 0",
        "model": "FriendlyElec NanoPi R5C",
        "board_name": "friendlyarm,nanopi-r5c",
        "rootfs_type": "ext4",
        "release": {
                "distribution": "OpenWrt",
                "version": "24.10.1",
                "revision": "r28597-0425664679",
                "target": "rockchip/armv8",
                "description": "OpenWrt 24.10.1 r28597-0425664679",
                "builddate": "1744562312"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 56336 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  64.8 MBytes   543 Mbits/sec    0    383 KBytes
[  5]   1.00-2.00   sec  63.9 MBytes   536 Mbits/sec    0    407 KBytes
[  5]   2.00-3.00   sec  63.0 MBytes   528 Mbits/sec    0    407 KBytes
[  5]   3.00-4.00   sec  63.4 MBytes   532 Mbits/sec    0    468 KBytes
[  5]   4.00-5.00   sec  63.6 MBytes   534 Mbits/sec    0    468 KBytes
[  5]   5.00-6.00   sec  64.4 MBytes   540 Mbits/sec    0    468 KBytes
[  5]   6.00-7.00   sec  64.0 MBytes   537 Mbits/sec    0    468 KBytes
[  5]   7.00-8.00   sec  64.4 MBytes   540 Mbits/sec    0    468 KBytes
[  5]   8.00-9.00   sec  64.0 MBytes   537 Mbits/sec    0    468 KBytes
[  5]   9.00-10.00  sec  64.8 MBytes   543 Mbits/sec    0    468 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   640 MBytes   537 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   639 MBytes   536 Mbits/sec                  receiver

iperf Done.
4242/tcp:            12189
root@OpenWRT-R5C:~#