### PR TITLE
Added GL.iNet GL-MT300N-V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Buffalo WCR-1166DS / MT7628AN    | OpenWrt 23.05.2 / 5.15.137       | 18.3 Mbits/sec | |
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
 | TP-Link WR841N v9 / QCA9533      | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
+| GL-iNet MT300N V2 / MT7628AN     | OpenWrt 23.05.5 / 5.15.167       | 19.4 Mbits/sec | |
 | AVM FRITZ!Box 3490 / VRX288      | OpenWrt SNAPSHOT / 3.17.1        | 26.1 Mbits/sec | |
 | TP-Link Archer C7 v2 / QCA9558   | OpenWrt 23.05.5 / 5.15.167       | 35.2 Mbits/sec | |
 | Ubiquiti UniFi AC LR / QCA956X   | OpenWrt 24.10.0 / 6.6.73         | 35.6 Mbits/sec | |


### PR DESCRIPTION
Router details:
{
        "kernel": "5.15.167",
        "hostname": "GL-MT300N-V2",
        "system": "MediaTek MT7628AN ver:1 eco:2",
        "model": "GL-MT300N-V2",
        "board_name": "glinet,gl-mt300n-v2",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "23.05.5",
                "revision": "r24106-10cc5fcd00",
                "target": "ramips/mt76x8",
                "description": "OpenWrt 23.05.5 r24106-10cc5fcd00"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 60348 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  2.25 MBytes  18.9 Mbits/sec    0   86.8 KBytes
[  5]   1.00-2.00   sec  2.38 MBytes  19.9 Mbits/sec    0    126 KBytes
[  5]   2.00-3.00   sec  2.25 MBytes  18.9 Mbits/sec    0    132 KBytes
[  5]   3.00-4.00   sec  2.25 MBytes  18.9 Mbits/sec    0    139 KBytes
[  5]   4.00-5.00   sec  2.38 MBytes  19.9 Mbits/sec    0    154 KBytes
[  5]   5.00-6.00   sec  2.12 MBytes  17.8 Mbits/sec    0    154 KBytes
[  5]   6.00-7.00   sec  2.50 MBytes  21.0 Mbits/sec    0    170 KBytes
[  5]   7.00-8.00   sec  2.38 MBytes  19.9 Mbits/sec    0    170 KBytes
[  5]   8.00-9.00   sec  2.25 MBytes  18.9 Mbits/sec    0    170 KBytes
[  5]   9.00-10.00  sec  2.38 MBytes  19.9 Mbits/sec    0    170 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  23.1 MBytes  19.4 Mbits/sec    0             sender
[  5]   0.00-10.03  sec  22.6 MBytes  18.9 Mbits/sec                  receiver

iperf Done.
4242/tcp:             5019