### PR TITLE
Added GL.iNet GL-E750

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Toshiba Satellite 480CDT / Pentium MMX 233MHz | Alpine Linux 3.18 / 6.2.0-rc7 | 3.2 Mbits/sec   | |
 | Raspberry Pi Model B / BCM2835   | OpenWrt 23.05.2 / 5.15.137       | 16.1 Mbits/sec | |
 | Buffalo WCR-1166DS / MT7628AN    | OpenWrt 23.05.2 / 5.15.137       | 18.3 Mbits/sec | |
+| GL-iNet GL-E750 / QCA9533        | OpenWrt 22.03.4 / 5.10.176       | 19.0 Mbits/sec | |
 | GL-iNet MT300N V1 / MT7620N      | OpenWrt 23.05.2 / 5.15.137       | 19.2 Mbits/sec | |
 | TP-Link WR841N v9 / QCA9533      | OpenWrt 22.03.6 / 5.10.201       | 19.2 Mbits/sec | |
 | GL-iNet MT300N V2 / MT7628AN     | OpenWrt 23.05.5 / 5.15.167       | 19.4 Mbits/sec | |


### PR DESCRIPTION
Router details:
{
        "kernel": "5.10.176",
        "hostname": "GL-E750",
        "system": "Qualcomm Atheros QCA9533 ver 2 rev 0",
        "model": "GL.iNet GL-E750",
        "board_name": "glinet,gl-e750",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "22.03.4",
                "revision": "r20123-38ccc47687",
                "target": "ath79/nand",
                "description": "OpenWrt 22.03.4 r20123-38ccc47687"
        }
}
Connecting to host 169.254.200.2, port 4242
[  5] local 169.254.200.1 port 40270 connected to 169.254.200.2 port 4242
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.98 MBytes  16.6 Mbits/sec    0    102 KBytes
[  5]   1.00-2.00   sec  2.45 MBytes  20.6 Mbits/sec    0    111 KBytes
[  5]   2.00-3.00   sec  2.39 MBytes  20.1 Mbits/sec    0    111 KBytes
[  5]   3.00-4.00   sec  2.45 MBytes  20.6 Mbits/sec    0    111 KBytes
[  5]   4.00-5.00   sec  2.45 MBytes  20.6 Mbits/sec    0    111 KBytes
[  5]   5.00-6.00   sec  2.15 MBytes  18.0 Mbits/sec    0    111 KBytes
[  5]   6.00-7.00   sec  2.02 MBytes  17.0 Mbits/sec    0    111 KBytes
[  5]   7.00-8.00   sec  2.58 MBytes  21.6 Mbits/sec    0    171 KBytes
[  5]   8.00-9.00   sec  2.45 MBytes  20.5 Mbits/sec    0    171 KBytes
[  5]   9.00-10.00  sec  2.27 MBytes  19.1 Mbits/sec    0    171 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  23.2 MBytes  19.5 Mbits/sec    0             sender
[  5]   0.00-10.03  sec  22.8 MBytes  19.0 Mbits/sec                  receiver

iperf Done.
4242/tcp:             2670