### PR TITLE
Add Xeon E3-1220

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | OrangePi 5 / Rockchip rk3588s*   | Armbian23.8.1 / 5.10.110 / -R    | 2.35 Gbits/sec | |
 | AMD EPYC 7D12                    | Linux pve / 6.2.16               | 2.45 Gbits/sec | |
 | Intel Celeron N5105*             | Debian bookworm / 6.1.38         | 2.46 Gbits/sec | |
+| Intel Xeon E3-1220               | Debian bookworm / 6.1.37         | 2.47 Gbits/sec | |
 | Intel Xeon Gold 6330             | Linux pve / 5.15.108             | 2.54 Gbits/sec | |
 | Raspberry Pi 5 / BCM2712         | Raspberry Pi OS / 6.1.68         | 2.60 Gbits/sec | |
 | Huawei Qingyun W510 / HiSilicon Kunpeng 920 3211k | Debian bookworm / 6.1.124 | 2.67 Gbits/sec | With 32-core unlock mod |


### PR DESCRIPTION
```
root@srv102:~/wg-bench# ./benchmark.sh
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 41854 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   288 MBytes  2.41 Gbits/sec   55    709 KBytes
[  5]   1.00-2.00   sec   293 MBytes  2.46 Gbits/sec    0    820 KBytes
[  5]   2.00-3.00   sec   277 MBytes  2.32 Gbits/sec    4    707 KBytes
[  5]   3.00-4.00   sec   296 MBytes  2.49 Gbits/sec    0    847 KBytes
[  5]   4.00-5.00   sec   263 MBytes  2.20 Gbits/sec   84    391 KBytes
[  5]   5.00-6.00   sec   277 MBytes  2.32 Gbits/sec    0    604 KBytes
[  5]   6.00-7.00   sec   297 MBytes  2.48 Gbits/sec    0    803 KBytes
[  5]   7.00-8.00   sec   341 MBytes  2.87 Gbits/sec  158    628 KBytes
[  5]   8.00-9.00   sec   318 MBytes  2.67 Gbits/sec   17    703 KBytes
[  5]   9.00-10.00  sec   300 MBytes  2.52 Gbits/sec    0    822 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  2.88 GBytes  2.47 Gbits/sec  318             sender
[  5]   0.00-10.00  sec  2.88 GBytes  2.47 Gbits/sec                  receiver
```

```
root@srv102:~/wg-bench# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

```
root@srv102:~/wg-bench# lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         36 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  4
  On-line CPU(s) list:   0-3
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Xeon(R) CPU E31220 @ 3.10GHz
    CPU family:          6
    Model:               42
    Thread(s) per core:  1
    Core(s) per socket:  4
    Socket(s):           1
```
