### PR TITLE
Add Orange Pi RV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Lemote A1601 / Loongson 3A2000   | AOSC OS 12.0.4 / 6.12.13-aosc-lts | 346 Mbits/sec | Highest of 5 runs |
 | Fortinet FortiGate 50E / 88F6820 | OpenWrt 24.10.1 / 6.6.86         | 347 Mbits/sec  | |
 | Phytium Pi (V2.2) / E2000Q FT310 (1.5GHz) | deepin V23 Beta3 / 5.10.209 | 358 Mbits/sec | With FT664 "big" cores disabled |
+| Orange Pi RV2 / Ky X1            | Debian trixie / 6.6.63           | 361 Mbits/sec  | Image from https://romanrm.net/rv-debian |
 | Linksys WRT1900ACv2  / 88F6820   | OpenWrt 23.05.2 / 5.15.137       | 361 Mbits/sec  | |
 | GL.iNet GL-MT2500 (Brume 2)      | OpenWrt 21.02-SNAPSHOT           | 362 Mbits/sec  | |
 | Linksys E8450 (UBI) / MT7622BV   | OpenWrt 23.05.5 / 5.15.167       | 368 Mbits/sec  | |


### PR DESCRIPTION
Benchmark result:
```
root@orangepirv2:~/wg-bench# ./benchmark.sh 
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 52606 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  39.9 MBytes   334 Mbits/sec    0    354 KBytes       
[  5]   1.00-2.00   sec  43.6 MBytes   366 Mbits/sec    0    374 KBytes       
[  5]   2.00-3.00   sec  42.5 MBytes   357 Mbits/sec    0    374 KBytes       
[  5]   3.00-4.00   sec  43.0 MBytes   361 Mbits/sec    0    374 KBytes       
[  5]   4.00-5.00   sec  42.8 MBytes   359 Mbits/sec    0    410 KBytes       
[  5]   5.00-6.00   sec  43.8 MBytes   367 Mbits/sec    0    428 KBytes       
[  5]   6.00-7.00   sec  43.4 MBytes   364 Mbits/sec    0    428 KBytes       
[  5]   7.00-8.00   sec  43.5 MBytes   365 Mbits/sec    0    428 KBytes       
[  5]   8.00-9.00   sec  43.5 MBytes   365 Mbits/sec    0    466 KBytes       
[  5]   9.00-10.00  sec  43.5 MBytes   364 Mbits/sec    0    466 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   430 MBytes   361 Mbits/sec    0            sender
[  5]   0.00-10.01  sec   429 MBytes   359 Mbits/sec                  receiver

iperf Done.
```
`fastfetch`:
```
root@orangepirv2
----------------
OS: Orange Pi 1.0.0 Trixie riscv64
Host: ky x1 orangepi-rv2 board
Kernel: Linux 6.6.63-ky
Uptime: 43 mins
Packages: 341 (dpkg)
Shell: bash 5.2.37
Display (MACROSILICON): 1280x720 @ 60 Hz in 24" [External]
Terminal: /dev/ttyS0
Terminal Font: VGA default kernel font 8x16x512
CPU: x1 (8) @ 1.60 GHz
Memory: 269.36 MiB / 1.91 GiB (14%)
Swap: Disabled
Disk (/): 1.30 GiB / 56.76 GiB (2%) - ext4
Local IP (end0): 192.168.101.134/24
Locale: en_US.UTF-8
```
`/etc/os-release`:
```ini
PRETTY_NAME="Orange Pi 1.0.0 Trixie"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.0
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```