### PR TITLE
Add Raspberry Pi 2B v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Asus RT-AC68U / BCM5301X         | OpenWRT 24.10.2 / 6.6.93         | 140 Mbit/sec   | Stock 2 core 1.0 GHz |
 | Google WiFi (Gale) / IPQ4019     | OpenWrt 23.05.2 / 5.15.137       | 164 Mbits/sec  | |
 | AVM FRITZ!Box 7530 / ipq40xx     | OpenWrt 23.05.2 / 5.15.137       | 184 Mbits/sec | |
+| Raspberry Pi 2B v1.1 / BCM2836   | Debian bullseye / 6.1.21         | 192 Mbits/sec | |
 | P&W R619AC 128M / IPQ4019     | OpenWrt 23.05.4 / 5.15.164       | 201 Mbits/sec  | Overclocked 896 MHz |
 | Xiaomi Mi Router R3D / IPQ8064   | OpenWrt Snapshot / 6.1.77       | 214 Mbits/sec  | |
 | NanoPi R2S / RK3328              | OpenWrt 23.05.2 / 5.15.137       | 234 Mbits/sec  | |


### PR DESCRIPTION
**Benchmark result:**

```
pi@raspberrypi:~/Downloads/wg-bench $ sudo ./benchmark.sh
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 58728 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  22.9 MBytes   192 Mbits/sec    0    325 KBytes
[  5]   1.00-2.00   sec  22.6 MBytes   189 Mbits/sec    0    325 KBytes
[  5]   2.00-3.00   sec  22.9 MBytes   192 Mbits/sec    0    339 KBytes
[  5]   3.00-4.00   sec  22.2 MBytes   186 Mbits/sec    0    374 KBytes
[  5]   4.00-5.00   sec  22.4 MBytes   188 Mbits/sec    0    374 KBytes
[  5]   5.00-6.00   sec  22.7 MBytes   191 Mbits/sec    0    374 KBytes
[  5]   6.00-7.00   sec  23.1 MBytes   193 Mbits/sec    0    374 KBytes
[  5]   7.00-8.00   sec  23.3 MBytes   196 Mbits/sec    0    374 KBytes
[  5]   8.00-9.00   sec  23.2 MBytes   194 Mbits/sec    0    374 KBytes
[  5]   9.00-10.00  sec  23.2 MBytes   195 Mbits/sec    0    374 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   228 MBytes   192 Mbits/sec    0             sender
[  5]   0.00-10.05  sec   228 MBytes   190 Mbits/sec                  receiver

iperf Done.
```
**Neofetch:** (for some reason neofetch thinks the CPU is BCM2835, but it's not)

```
pi@raspberrypi:~/Downloads/wg-bench $ neofetch
  `.::///+:/-.        --///+//-:``    pi@raspberrypi
 `+oooooooooooo:   `+oooooooooooo:    --------------
  /oooo++//ooooo:  ooooo+//+ooooo.    OS: Raspbian GNU/Linux 11 (bullseye) armv7l
  `+ooooooo:-:oo-  +o+::/ooooooo:     Host: Raspberry Pi 2 Model B Rev 1.1
   `:oooooooo+``    `.oooooooo+-      Kernel: 6.1.21-v7+
     `:++ooo/.        :+ooo+/.`       Uptime: 16 days, 5 hours, 25 mins
        ...`  `.----.` ``..           Packages: 1990 (dpkg)
     .::::-``:::::::::.`-:::-`        Shell: bash 5.1.4
    -:::-`   .:::::::-`  `-:::-       Terminal: /dev/pts/0
   `::.  `.--.`  `` `.---.``.::`      CPU: BCM2835 (4) @ 900MHz
       .::::::::`  -::::::::` `       Memory: 240MiB / 870MiB
 .::` .:::::::::- `::::::::::``::.
-:::` ::::::::::.  ::::::::::.`:::-
::::  -::::::::.   `-::::::::  ::::
-::-   .-:::-.``....``.-::-.   -::-
 .. ``       .::::::::.     `..`..
   -:::-`   -::::::::::`  .:::::`
   :::::::` -::::::::::` :::::::.
   .:::::::  -::::::::. ::::::::
    `-:::::`   ..--.`   ::::::.
      `...`  `...--..`  `...`
            .::::::::::
             `.-::::-`
```
**/etc/os-release:**

```
pi@raspberrypi:~/Downloads/wg-bench $ cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
NAME="Raspbian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```