### PR TITLE
Add OneThingCloud OES

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | iEi Puzzle-M902 / Marvell CN9130 | OpenWRT 23.05.03 / 5.15.150      | 1.43 Gbits/sec | |
 | Phytium D2000x8 (2.3GHz)         | Debian trixie / 6.11.7           | 1.49 Gbits/sec | |
 | Intel Celeron N4500              | Linux pve / 6.2.16-3-pve         | 1.54 Gbits/sec | |
+| OneThingCloud OES / Amlogic A311D | Armbian Trixie / 6.18.16-ophub   | 1.55 Gbits/sec | |
 | Intel i5-7300U                   | ArchLinux / 6.17.1-2-cachyos     | 1.59 Gbits/sec | |
 | Radxa NIO12L / MT8395            | Ubuntu 22.04 / 5.15.0            | 1.60 Gbits/sec  | Only enable A78 cores |
 | Mac Mini (2020) / Apple M1*      | AsahiLinux / 6.5.0               | 1.60 Gbits/sec | |


### PR DESCRIPTION
```bash
armbian:wg-bench:# ./setup-netns.sh                                                                            <master>
armbian:wg-bench:# ./benchmark.sh                                                                              <master>
Connecting to host 169.254.200.2, port 5201
[  5] local 169.254.200.1 port 45010 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   188 MBytes  1.57 Gbits/sec    0    540 KBytes
[  5]   1.00-2.00   sec   186 MBytes  1.56 Gbits/sec    0    553 KBytes
[  5]   2.00-3.00   sec   187 MBytes  1.57 Gbits/sec    0    556 KBytes
[  5]   3.00-4.00   sec   185 MBytes  1.56 Gbits/sec    0    615 KBytes
[  5]   4.00-5.00   sec   186 MBytes  1.56 Gbits/sec    0    532 KBytes
[  5]   5.00-6.00   sec   186 MBytes  1.56 Gbits/sec    0    553 KBytes
[  5]   6.00-7.00   sec   184 MBytes  1.55 Gbits/sec    0    545 KBytes
[  5]   7.00-8.00   sec   185 MBytes  1.55 Gbits/sec    0    558 KBytes
[  5]   8.00-9.00   sec   185 MBytes  1.55 Gbits/sec    0    540 KBytes
[  5]   9.00-10.00  sec   185 MBytes  1.55 Gbits/sec    0   5.34 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  1.81 GBytes  1.56 Gbits/sec    0            sender
[  5]   0.00-10.00  sec  1.81 GBytes  1.55 Gbits/sec                  receiver

iperf Done.
armbian:wg-bench:# ./benchmark.sh -R                                                                           <master>
Connecting to host 169.254.200.2, port 5201
Reverse mode, remote host 169.254.200.2 is sending
[  5] local 169.254.200.1 port 7822 connected to 169.254.200.2 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   183 MBytes  1.53 Gbits/sec
[  5]   1.00-2.00   sec   184 MBytes  1.54 Gbits/sec
[  5]   2.00-3.00   sec   186 MBytes  1.56 Gbits/sec
[  5]   3.00-4.00   sec   185 MBytes  1.55 Gbits/sec
[  5]   4.00-5.00   sec   184 MBytes  1.54 Gbits/sec
[  5]   5.00-6.00   sec   185 MBytes  1.55 Gbits/sec
[  5]   6.00-7.00   sec   185 MBytes  1.56 Gbits/sec
[  5]   7.00-8.00   sec   183 MBytes  1.54 Gbits/sec
[  5]   8.00-9.00   sec   183 MBytes  1.54 Gbits/sec
[  5]   9.00-10.00  sec   185 MBytes  1.55 Gbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  1.80 GBytes  1.55 Gbits/sec    0            sender
[  5]   0.00-10.00  sec  1.80 GBytes  1.55 Gbits/sec                  receiver

iperf Done.
armbian:wg-bench:# ./clean-up.sh                                                                               <master>
armbian:wg-bench:# lscpu                                                                                       <master>
Architecture:                aarch64
  CPU op-mode(s):            32-bit, 64-bit
  Byte Order:                Little Endian
CPU(s):                      6
  On-line CPU(s) list:       0-5
Vendor ID:                   ARM
  Model name:                Cortex-A53
    Model:                   4
    Thread(s) per core:      1
    Core(s) per socket:      2
    Socket(s):               1
    Stepping:                r0p4
    Frequency boost:         disabled
    CPU(s) scaling MHz:      78%
    CPU max MHz:             1800.0000
    CPU min MHz:             1000.0000
    BogoMIPS:                48.00
    Flags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
  Model name:                Cortex-A73
    Model:                   2
    Thread(s) per core:      1
    Core(s) per socket:      4
    Socket(s):               1
    Stepping:                r0p2
    CPU(s) scaling MHz:      73%
    CPU max MHz:             2208.0000
    CPU min MHz:             1000.0000
    BogoMIPS:                48.00
    Flags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
Caches (sum of all):
  L1d:                       256 KiB (6 instances)
  L1i:                       256 KiB (6 instances)
  L2:                        1 MiB (1 instance)
Vulnerabilities:
  Gather data sampling:      Not affected
  Ghostwrite:                Not affected
  Indirect target selection: Not affected
  Itlb multihit:             Not affected
  L1tf:                      Not affected
  Mds:                       Not affected
  Meltdown:                  Not affected
  Mmio stale data:           Not affected
  Old microcode:             Not affected
  Reg file data sampling:    Not affected
  Retbleed:                  Not affected
  Spec rstack overflow:      Not affected
  Spec store bypass:         Vulnerable
  Spectre v1:                Mitigation; __user pointer sanitization
  Spectre v2:                Vulnerable
  Srbds:                     Not affected
  Tsa:                       Not affected
  Tsx async abort:           Not affected
  Vmscape:                   Not affected
armbian:wg-bench:# uname -a                                                                                    <master>
Linux armbian 6.18.16-ophub #1 SMP PREEMPT_DYNAMIC Thu Mar  5 06:59:14 UTC 2026 aarch64 GNU/Linux
```