### PR TITLE
Add Nokia Bell XG-040G-MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ sh <(wget -O - https://raw.githubusercontent.com/cyyself/wg-bench/master/openwrt
 | Linksys MX4300 / IPQ8174         | OpenWRT 24.10.0-rc2 / 6.6.63     | 443 Mbits/sec  | |
 | Sipeed Lichee Pi 4A / TH1520     | RevyOS / 6.6.4                   | 451 Mbits/sec  | |
 | JDCloud RE-CS-02 / IPQ6018       | ImmortalWRT SNAPSHOT / 6.12.62   | 481 Mbits/sec  | arm64 system by VIKINGYFY/immortalwrt, bypass os-release NAME check |
+| Nokia Bell XG-040G-MD / AN7581   | OpenWrt 25.12.0 / 6.12.71 | 494 Mbits/sec  | Build from patches proposed in openwrt #21896, not yet official |
 | Raspberry Pi Model 3B / BCM2837  | OpenWRT 23.05.2 / 5.15.137       | 522 Mbits/sec  | |
 | Phicomm N1 / S905D               | ophub-openwrt / 6.1.66           | 537 Mbits/sec  | |
 | FriendlyELECT NanoPi R5C / RK3568B2 | OpenWRT / 24.10.1             | 537 Mbits/sec  | |


### PR DESCRIPTION
This is a router used by CMCC for XGPON installations. The device does NOT have wifi, but does have an NPU. No clue on its' usefulness.

The build of 25.12.0 used was unofficial. There are no official builds yet. See PR #21896 in openwrt/openwrt.

I could test on 25.12.1, but I do not have builds for it yet. Plus, it doesn't look like there may be much of a performance difference.